### PR TITLE
fix: swagger 실패 해결

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,3 +25,5 @@ logging:
     org.hibernate.orm.sql.ast: WARN
     org.hibernate.orm.results: WARN
 
+server:
+  forward-headers-strategy: framework


### PR DESCRIPTION
- 리버스 프록시(Nginx) 뒤에서 들어오는 요청의 원래 정보를 스프링이 신뢰하고 해석하도록 추가