### PR TITLE
feat: 공지사항·문의하기 API 추가

### DIFF
--- a/docs/spec/api-overview.md
+++ b/docs/spec/api-overview.md
@@ -592,6 +592,241 @@ Query:
 - `DELETE /reviews/{reviewId}/bookmarks`
 - Auth: 필요
 
+## Notice
+
+### 공지사항 목록 조회
+
+- `GET /notices`
+- Auth: 없음
+
+Query:
+
+- `page`
+- `size`
+
+출력:
+
+- `NoticeListResponseDto`
+
+비고:
+
+- 공개된 공지사항만 조회
+- 고정 공지가 우선 노출되고 최신순 정렬
+
+### 공지사항 상세 조회
+
+- `GET /notices/{noticeId}`
+- Auth: 없음
+
+출력:
+
+- `NoticeDetailResponseDto`
+
+대표 에러:
+
+- `O001 NOTICE_NOT_FOUND`
+
+### 공지사항 등록
+
+- `POST /admin/notices`
+- Auth: 필요
+
+입력:
+
+- `title`
+- `content`
+- `pinned`
+- `published`
+
+출력:
+
+- `201 Created`
+- `NoticeDetailResponseDto`
+
+대표 에러:
+
+- `A001`
+- `A002`
+- `M001`
+- `C002`
+
+비고:
+
+- 관리자만 등록 가능
+
+### 공지사항 수정
+
+- `PATCH /admin/notices/{noticeId}`
+- Auth: 필요
+
+입력:
+
+- `title`
+- `content`
+- `pinned`
+- `published`
+
+출력:
+
+- `NoticeDetailResponseDto`
+
+대표 에러:
+
+- `A001`
+- `A002`
+- `M001`
+- `O001`
+- `C002`
+
+### 공지사항 삭제
+
+- `DELETE /admin/notices/{noticeId}`
+- Auth: 필요
+
+대표 에러:
+
+- `A001`
+- `A002`
+- `M001`
+- `O001`
+
+## Inquiry
+
+### 문의 작성
+
+- `POST /inquiries`
+- Auth: 필요
+
+입력:
+
+- `title`
+- `content`
+
+출력:
+
+- `201 Created`
+- `InquiryDetailResponseDto`
+
+대표 에러:
+
+- `A001`
+- `M001`
+- `C002`
+
+### 내 문의 목록 조회
+
+- `GET /inquiries/me`
+- Auth: 필요
+
+Query:
+
+- `page`
+- `size`
+
+출력:
+
+- `InquiryListResponseDto`
+
+대표 에러:
+
+- `A001`
+- `C002`
+
+### 문의 상세 조회
+
+- `GET /inquiries/{inquiryId}`
+- Auth: 필요
+
+출력:
+
+- `InquiryDetailResponseDto`
+
+대표 에러:
+
+- `A001`
+- `A002`
+- `M001`
+- `Q001 INQUIRY_NOT_FOUND`
+
+비고:
+
+- 본인 문의 또는 관리자만 조회 가능
+
+### 문의 전체 조회
+
+- `GET /admin/inquiries`
+- Auth: 필요
+
+Query:
+
+- `page`
+- `size`
+
+출력:
+
+- `InquiryListResponseDto`
+
+대표 에러:
+
+- `A001`
+- `A002`
+- `M001`
+- `C002`
+
+비고:
+
+- 관리자만 조회 가능
+
+### 문의 답변 등록
+
+- `PATCH /admin/inquiries/{inquiryId}/answer`
+- Auth: 필요
+
+입력:
+
+- `answerContent`
+
+출력:
+
+- `InquiryDetailResponseDto`
+
+대표 에러:
+
+- `A001`
+- `A002`
+- `M001`
+- `Q001`
+- `C002`
+
+비고:
+
+- 답변 등록 시 상태는 `ANSWERED`로 변경
+
+### 문의 상태 변경
+
+- `PATCH /admin/inquiries/{inquiryId}/status`
+- Auth: 필요
+
+입력:
+
+- `status: PENDING | ANSWERED | CLOSED`
+
+출력:
+
+- `InquiryDetailResponseDto`
+
+대표 에러:
+
+- `A001`
+- `A002`
+- `M001`
+- `Q001`
+- `C002`
+
+비고:
+
+- 관리자만 상태 변경 가능
+
 ## Search
 
 ### 최근 검색어 조회
@@ -716,6 +951,10 @@ Query:
   - 댓글 없음
 - `R001`
   - 리뷰 없음
+- `O001`
+  - 공지사항 없음
+- `Q001`
+  - 문의 없음
 
 ## 프론트 체크리스트
 
@@ -725,3 +964,4 @@ Query:
 - validation 실패는 `C002`와 `message`를 그대로 사용자에게 노출 가능
 - 직접 등록 도서 수정은 등록자만 가능하므로 `ACCESS_DENIED` 처리 필요
 - 비공개 계정 설정은 현재 저장까지 반영되며, 실제 접근 제한 정책은 후속 반영 가능성 있음
+- 관리자 전용 공지/문의 API는 토큰이 있어도 일반 사용자면 `A002` 처리

--- a/src/main/java/monochrome/libri/follow/repository/FollowRepository.java
+++ b/src/main/java/monochrome/libri/follow/repository/FollowRepository.java
@@ -1,6 +1,7 @@
 package monochrome.libri.follow.repository;
 
 import monochrome.libri.follow.domain.Follow;
+import monochrome.libri.follow.domain.FollowStatus;
 import monochrome.libri.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,6 @@ import java.util.Optional;
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {
     Optional<Follow> findByFollowerAndFollowing(Member follower, Member following);
+    long countByFollowingAndFollowStatus(Member following, FollowStatus followStatus);
+    long countByFollowerAndFollowStatus(Member follower, FollowStatus followStatus);
 }

--- a/src/main/java/monochrome/libri/follow/service/FollowServiceImpl.java
+++ b/src/main/java/monochrome/libri/follow/service/FollowServiceImpl.java
@@ -91,11 +91,13 @@ public class FollowServiceImpl implements FollowService{
 
     @Override
     public Slice<MemberSummaryDto> findFollowers(Long memberId, Pageable pageable) {
-        return null;
+        Member member = getMemberOrThrow(memberId);
+        return followRepository.findFollowers(member, pageable);
     }
 
     @Override
     public Slice<MemberSummaryDto> findFollowings(Long memberId, Pageable pageable) {
-        return null;
+        Member member = getMemberOrThrow(memberId);
+        return followRepository.findFollowings(member, pageable);
     }
 }

--- a/src/main/java/monochrome/libri/global/exception/ErrorCode.java
+++ b/src/main/java/monochrome/libri/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "노트를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "N002", "댓글을 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "공지사항을 찾을 수 없습니다."),
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "문의 내역을 찾을 수 없습니다."),
 
     // 팔로우
     EXIST_FOLLOW_RELATION(HttpStatus.CONFLICT, "F001", "이미 팔로우한 회원입니다."),

--- a/src/main/java/monochrome/libri/home/dto/response/HomeResponseDto.java
+++ b/src/main/java/monochrome/libri/home/dto/response/HomeResponseDto.java
@@ -14,6 +14,8 @@ public record HomeResponseDto(
             Long memberId,
             String nickname,
             String profileImageUrl,
+            long followerCount,
+            long followingCount,
             int unreadNotiCount
     ) {
     }

--- a/src/main/java/monochrome/libri/home/service/impl/HomeServiceImpl.java
+++ b/src/main/java/monochrome/libri/home/service/impl/HomeServiceImpl.java
@@ -1,5 +1,7 @@
 package monochrome.libri.home.service.impl;
 
+import monochrome.libri.follow.domain.FollowStatus;
+import monochrome.libri.follow.repository.FollowRepository;
 import monochrome.libri.global.exception.ErrorCode;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.home.dto.response.HomeResponseDto;
@@ -25,11 +27,18 @@ public class HomeServiceImpl implements HomeService {
     private static final int HOME_BOOK_PREVIEW_LIMIT = 3;
 
     private final MemberService memberService;
+    private final FollowRepository followRepository;
     private final ShelfRepository shelfRepository;
     private final Clock clock;
 
-    public HomeServiceImpl(MemberService memberService, ShelfRepository shelfRepository, Clock clock) {
+    public HomeServiceImpl(
+            MemberService memberService,
+            FollowRepository followRepository,
+            ShelfRepository shelfRepository,
+            Clock clock
+    ) {
         this.memberService = memberService;
+        this.followRepository = followRepository;
         this.shelfRepository = shelfRepository;
         this.clock = clock;
     }
@@ -60,17 +69,21 @@ public class HomeServiceImpl implements HomeService {
 
     private HomeResponseDto.MeSummary buildMeSummary(Long memberId) {
         if (memberId == null) {
-            return new HomeResponseDto.MeSummary(null, null, null, 0);
+            return new HomeResponseDto.MeSummary(null, null, null, 0, 0, 0);
         }
 
         Member member = memberService.getMemberById(memberId)
                 .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
+        long followerCount = followRepository.countByFollowingAndFollowStatus(member, FollowStatus.FOLLOW);
+        long followingCount = followRepository.countByFollowerAndFollowStatus(member, FollowStatus.FOLLOW);
 
         // TODO: 현재 알림 기능이 없으므로 미확인 알림 수는 0으로 설정
         return new HomeResponseDto.MeSummary(
                 member.getId(),
                 member.getNickname(),
                 member.getProfilePath(),
+                followerCount,
+                followingCount,
                 0
         );
     }
@@ -103,7 +116,7 @@ public class HomeServiceImpl implements HomeService {
         return rows.stream()
                 .map(row -> {
                     int totalPage = safeInt(row.totalPage());
-                    int currentPage = safeInt(row.currentPage());
+                    int currentPage = resolveCurrentPage(row.progressType(), row.currentPage(), row.progressValue());
                     int progressPercent = calculateProgressPercent(
                             row.progressType(),
                             safeInt(row.progressValue()),
@@ -147,6 +160,17 @@ public class HomeServiceImpl implements HomeService {
 
     private int safeInt(Integer value) {
         return value == null ? 0 : value;
+    }
+
+    private int resolveCurrentPage(
+            monochrome.libri.shelf.domain.ShelfProgressType progressType,
+            Integer currentPage,
+            Integer progressValue
+    ) {
+        if (progressType == monochrome.libri.shelf.domain.ShelfProgressType.PAGE && currentPage == null) {
+            return safeInt(progressValue);
+        }
+        return safeInt(currentPage);
     }
 
     private int calculateProgressPercent(

--- a/src/main/java/monochrome/libri/inquiry/controller/InquiryController.java
+++ b/src/main/java/monochrome/libri/inquiry/controller/InquiryController.java
@@ -1,0 +1,161 @@
+package monochrome.libri.inquiry.controller;
+
+import jakarta.validation.Valid;
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.global.response.ApiResponse;
+import monochrome.libri.global.security.UserPrincipal;
+import monochrome.libri.global.swagger.ApiErrorCodes;
+import monochrome.libri.inquiry.dto.request.InquiryAnswerRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryCreateRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryStatusUpdateRequestDto;
+import monochrome.libri.inquiry.dto.response.InquiryDetailResponseDto;
+import monochrome.libri.inquiry.dto.response.InquiryListResponseDto;
+import monochrome.libri.inquiry.service.InquiryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    public InquiryController(InquiryService inquiryService) {
+        this.inquiryService = inquiryService;
+    }
+
+    @PostMapping("/inquiries")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "문의 작성", description = "로그인한 회원이 문의를 작성합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<InquiryDetailResponseDto>> createInquiry(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody InquiryCreateRequestDto request
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(inquiryService.createInquiry(memberId, request)));
+    }
+
+    @GetMapping("/inquiries/me")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "내 문의 목록 조회", description = "로그인한 회원의 문의 목록을 조회합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<InquiryListResponseDto>> getMyInquiries(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Parameter(description = "페이지(0부터)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        validatePage(page, size);
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"));
+        return ResponseEntity.ok(ApiResponse.ok(inquiryService.getMyInquiries(memberId, pageable)));
+    }
+
+    @GetMapping("/inquiries/{inquiryId}")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "문의 상세 조회", description = "본인 문의 또는 관리자는 문의 상세를 조회할 수 있습니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INQUIRY_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<InquiryDetailResponseDto>> getInquiry(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable long inquiryId
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        return ResponseEntity.ok(ApiResponse.ok(inquiryService.getInquiry(inquiryId, memberId)));
+    }
+
+    @GetMapping("/admin/inquiries")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "문의 전체 조회", description = "관리자가 전체 문의 목록을 조회합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<InquiryListResponseDto>> getAllInquiries(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Parameter(description = "페이지(0부터)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        validatePage(page, size);
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"));
+        return ResponseEntity.ok(ApiResponse.ok(inquiryService.getAllInquiries(memberId, pageable)));
+    }
+
+    @PatchMapping("/admin/inquiries/{inquiryId}/answer")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "문의 답변 등록", description = "관리자가 문의에 답변을 등록합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INQUIRY_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<InquiryDetailResponseDto>> answerInquiry(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable long inquiryId,
+            @Valid @RequestBody InquiryAnswerRequestDto request
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        return ResponseEntity.ok(ApiResponse.ok(inquiryService.answerInquiry(memberId, inquiryId, request)));
+    }
+
+    @PatchMapping("/admin/inquiries/{inquiryId}/status")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "문의 상태 변경", description = "관리자가 문의 상태를 변경합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INQUIRY_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<InquiryDetailResponseDto>> updateInquiryStatus(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable long inquiryId,
+            @RequestBody InquiryStatusUpdateRequestDto request
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        return ResponseEntity.ok(ApiResponse.ok(inquiryService.updateInquiryStatus(memberId, inquiryId, request)));
+    }
+
+    private void validatePage(int page, int size) {
+        if (page < 0 || size <= 0) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+}

--- a/src/main/java/monochrome/libri/inquiry/domain/Inquiry.java
+++ b/src/main/java/monochrome/libri/inquiry/domain/Inquiry.java
@@ -1,0 +1,63 @@
+package monochrome.libri.inquiry.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import monochrome.libri.global.domain.AuditableEntity;
+import monochrome.libri.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Inquiry extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, length = 5000)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private InquiryStatus status;
+
+    @Column(length = 5000)
+    private String answerContent;
+
+    private LocalDateTime answeredAt;
+
+    public void answer(String answerContent, LocalDateTime answeredAt) {
+        this.answerContent = answerContent;
+        this.answeredAt = answeredAt;
+        this.status = InquiryStatus.ANSWERED;
+    }
+
+    public void updateStatus(InquiryStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/monochrome/libri/inquiry/domain/InquiryStatus.java
+++ b/src/main/java/monochrome/libri/inquiry/domain/InquiryStatus.java
@@ -1,0 +1,7 @@
+package monochrome.libri.inquiry.domain;
+
+public enum InquiryStatus {
+    PENDING,
+    ANSWERED,
+    CLOSED
+}

--- a/src/main/java/monochrome/libri/inquiry/dto/request/InquiryAnswerRequestDto.java
+++ b/src/main/java/monochrome/libri/inquiry/dto/request/InquiryAnswerRequestDto.java
@@ -1,0 +1,9 @@
+package monochrome.libri.inquiry.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record InquiryAnswerRequestDto(
+        @NotBlank(message = "답변 내용은 필수입니다.")
+        String answerContent
+) {
+}

--- a/src/main/java/monochrome/libri/inquiry/dto/request/InquiryCreateRequestDto.java
+++ b/src/main/java/monochrome/libri/inquiry/dto/request/InquiryCreateRequestDto.java
@@ -1,0 +1,11 @@
+package monochrome.libri.inquiry.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record InquiryCreateRequestDto(
+        @NotBlank(message = "문의 제목은 필수입니다.")
+        String title,
+        @NotBlank(message = "문의 내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/monochrome/libri/inquiry/dto/request/InquiryStatusUpdateRequestDto.java
+++ b/src/main/java/monochrome/libri/inquiry/dto/request/InquiryStatusUpdateRequestDto.java
@@ -1,0 +1,8 @@
+package monochrome.libri.inquiry.dto.request;
+
+import monochrome.libri.inquiry.domain.InquiryStatus;
+
+public record InquiryStatusUpdateRequestDto(
+        InquiryStatus status
+) {
+}

--- a/src/main/java/monochrome/libri/inquiry/dto/response/InquiryDetailResponseDto.java
+++ b/src/main/java/monochrome/libri/inquiry/dto/response/InquiryDetailResponseDto.java
@@ -1,0 +1,33 @@
+package monochrome.libri.inquiry.dto.response;
+
+import monochrome.libri.inquiry.domain.Inquiry;
+
+import java.time.LocalDateTime;
+
+public record InquiryDetailResponseDto(
+        long inquiryId,
+        long memberId,
+        String memberNickname,
+        String title,
+        String content,
+        monochrome.libri.inquiry.domain.InquiryStatus status,
+        String answerContent,
+        LocalDateTime answeredAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static InquiryDetailResponseDto from(Inquiry inquiry) {
+        return new InquiryDetailResponseDto(
+                inquiry.getId(),
+                inquiry.getMember().getId(),
+                inquiry.getMember().getNickname(),
+                inquiry.getTitle(),
+                inquiry.getContent(),
+                inquiry.getStatus(),
+                inquiry.getAnswerContent(),
+                inquiry.getAnsweredAt(),
+                inquiry.getCreatedDate(),
+                inquiry.getLastModifiedDate()
+        );
+    }
+}

--- a/src/main/java/monochrome/libri/inquiry/dto/response/InquiryListItemResponseDto.java
+++ b/src/main/java/monochrome/libri/inquiry/dto/response/InquiryListItemResponseDto.java
@@ -1,0 +1,16 @@
+package monochrome.libri.inquiry.dto.response;
+
+import monochrome.libri.inquiry.domain.InquiryStatus;
+
+import java.time.LocalDateTime;
+
+public record InquiryListItemResponseDto(
+        long inquiryId,
+        long memberId,
+        String memberNickname,
+        String title,
+        InquiryStatus status,
+        LocalDateTime answeredAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/monochrome/libri/inquiry/dto/response/InquiryListResponseDto.java
+++ b/src/main/java/monochrome/libri/inquiry/dto/response/InquiryListResponseDto.java
@@ -1,0 +1,15 @@
+package monochrome.libri.inquiry.dto.response;
+
+import java.util.List;
+
+public record InquiryListResponseDto(
+        long totalCount,
+        List<InquiryListItemResponseDto> content,
+        boolean hasNext,
+        int page,
+        int size
+) {
+    public static InquiryListResponseDto empty(int page, int size) {
+        return new InquiryListResponseDto(0, List.of(), false, page, size);
+    }
+}

--- a/src/main/java/monochrome/libri/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/monochrome/libri/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,11 @@
+package monochrome.libri.inquiry.repository;
+
+import monochrome.libri.inquiry.domain.Inquiry;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+    Slice<Inquiry> findByMemberIdOrderByCreatedDateDesc(long memberId, Pageable pageable);
+    long countByMemberId(long memberId);
+}

--- a/src/main/java/monochrome/libri/inquiry/service/InquiryService.java
+++ b/src/main/java/monochrome/libri/inquiry/service/InquiryService.java
@@ -1,0 +1,17 @@
+package monochrome.libri.inquiry.service;
+
+import monochrome.libri.inquiry.dto.request.InquiryAnswerRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryCreateRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryStatusUpdateRequestDto;
+import monochrome.libri.inquiry.dto.response.InquiryDetailResponseDto;
+import monochrome.libri.inquiry.dto.response.InquiryListResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface InquiryService {
+    InquiryDetailResponseDto createInquiry(long memberId, InquiryCreateRequestDto request);
+    InquiryListResponseDto getMyInquiries(long memberId, Pageable pageable);
+    InquiryDetailResponseDto getInquiry(long inquiryId, long memberId);
+    InquiryListResponseDto getAllInquiries(long memberId, Pageable pageable);
+    InquiryDetailResponseDto answerInquiry(long memberId, long inquiryId, InquiryAnswerRequestDto request);
+    InquiryDetailResponseDto updateInquiryStatus(long memberId, long inquiryId, InquiryStatusUpdateRequestDto request);
+}

--- a/src/main/java/monochrome/libri/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/monochrome/libri/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,0 +1,148 @@
+package monochrome.libri.inquiry.service.impl;
+
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.inquiry.domain.Inquiry;
+import monochrome.libri.inquiry.domain.InquiryStatus;
+import monochrome.libri.inquiry.dto.request.InquiryAnswerRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryCreateRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryStatusUpdateRequestDto;
+import monochrome.libri.inquiry.dto.response.InquiryDetailResponseDto;
+import monochrome.libri.inquiry.dto.response.InquiryListItemResponseDto;
+import monochrome.libri.inquiry.dto.response.InquiryListResponseDto;
+import monochrome.libri.inquiry.repository.InquiryRepository;
+import monochrome.libri.inquiry.service.InquiryService;
+import monochrome.libri.member.domain.Member;
+import monochrome.libri.member.domain.Role;
+import monochrome.libri.member.service.MemberService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class InquiryServiceImpl implements InquiryService {
+
+    private final InquiryRepository inquiryRepository;
+    private final MemberService memberService;
+
+    public InquiryServiceImpl(InquiryRepository inquiryRepository, MemberService memberService) {
+        this.inquiryRepository = inquiryRepository;
+        this.memberService = memberService;
+    }
+
+    @Override
+    @Transactional
+    public InquiryDetailResponseDto createInquiry(long memberId, InquiryCreateRequestDto request) {
+        Member member = getMemberOrThrow(memberId);
+        if (request == null || request.title() == null || request.title().isBlank()
+                || request.content() == null || request.content().isBlank()) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Inquiry inquiry = Inquiry.builder()
+                .member(member)
+                .title(request.title().trim())
+                .content(request.content().trim())
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        return InquiryDetailResponseDto.from(inquiryRepository.save(inquiry));
+    }
+
+    @Override
+    public InquiryListResponseDto getMyInquiries(long memberId, Pageable pageable) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        Slice<Inquiry> slice = inquiryRepository.findByMemberIdOrderByCreatedDateDesc(memberId, pageable);
+        List<InquiryListItemResponseDto> content = toListItems(slice.getContent());
+        long totalCount = inquiryRepository.countByMemberId(memberId);
+        return new InquiryListResponseDto(totalCount, content, slice.hasNext(), slice.getNumber(), slice.getSize());
+    }
+
+    @Override
+    public InquiryDetailResponseDto getInquiry(long inquiryId, long memberId) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        Member actor = getMemberOrThrow(memberId);
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new LibriException(ErrorCode.INQUIRY_NOT_FOUND));
+        if (actor.getRole() != Role.ADMIN && inquiry.getMember().getId() != memberId) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
+        return InquiryDetailResponseDto.from(inquiry);
+    }
+
+    @Override
+    public InquiryListResponseDto getAllInquiries(long memberId, Pageable pageable) {
+        getAdminMember(memberId);
+        Slice<Inquiry> slice = inquiryRepository.findAll(pageable);
+        List<InquiryListItemResponseDto> content = toListItems(slice.getContent());
+        return new InquiryListResponseDto(inquiryRepository.count(), content, slice.hasNext(), slice.getNumber(), slice.getSize());
+    }
+
+    @Override
+    @Transactional
+    public InquiryDetailResponseDto answerInquiry(long memberId, long inquiryId, InquiryAnswerRequestDto request) {
+        getAdminMember(memberId);
+        if (request == null || request.answerContent() == null || request.answerContent().isBlank()) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new LibriException(ErrorCode.INQUIRY_NOT_FOUND));
+        inquiry.answer(request.answerContent().trim(), LocalDateTime.now());
+        return InquiryDetailResponseDto.from(inquiry);
+    }
+
+    @Override
+    @Transactional
+    public InquiryDetailResponseDto updateInquiryStatus(long memberId, long inquiryId, InquiryStatusUpdateRequestDto request) {
+        getAdminMember(memberId);
+        if (request == null || request.status() == null) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new LibriException(ErrorCode.INQUIRY_NOT_FOUND));
+        inquiry.updateStatus(request.status());
+        return InquiryDetailResponseDto.from(inquiry);
+    }
+
+    private List<InquiryListItemResponseDto> toListItems(List<Inquiry> inquiries) {
+        return inquiries.stream()
+                .map(inquiry -> new InquiryListItemResponseDto(
+                        inquiry.getId(),
+                        inquiry.getMember().getId(),
+                        inquiry.getMember().getNickname(),
+                        inquiry.getTitle(),
+                        inquiry.getStatus(),
+                        inquiry.getAnsweredAt(),
+                        inquiry.getCreatedDate()
+                ))
+                .toList();
+    }
+
+    private Member getMemberOrThrow(long memberId) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        return memberService.getMemberById(memberId)
+                .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Member getAdminMember(long memberId) {
+        Member member = getMemberOrThrow(memberId);
+        if (member.getRole() != Role.ADMIN) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
+        return member;
+    }
+}

--- a/src/main/java/monochrome/libri/notice/controller/AdminNoticeController.java
+++ b/src/main/java/monochrome/libri/notice/controller/AdminNoticeController.java
@@ -1,0 +1,87 @@
+package monochrome.libri.notice.controller;
+
+import jakarta.validation.Valid;
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.response.ApiResponse;
+import monochrome.libri.global.security.UserPrincipal;
+import monochrome.libri.global.swagger.ApiErrorCodes;
+import monochrome.libri.notice.dto.request.NoticeCreateRequestDto;
+import monochrome.libri.notice.dto.request.NoticeUpdateRequestDto;
+import monochrome.libri.notice.dto.response.NoticeDetailResponseDto;
+import monochrome.libri.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/notices")
+@SecurityRequirement(name = "BearerAuth")
+public class AdminNoticeController {
+
+    private final NoticeService noticeService;
+
+    public AdminNoticeController(NoticeService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    @PostMapping
+    @Operation(summary = "공지사항 등록", description = "관리자가 공지사항을 등록합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<NoticeDetailResponseDto>> createNotice(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody NoticeCreateRequestDto request
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        NoticeDetailResponseDto response = noticeService.createNotice(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+    }
+
+    @PatchMapping("/{noticeId}")
+    @Operation(summary = "공지사항 수정", description = "관리자가 공지사항을 수정합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.NOTICE_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<NoticeDetailResponseDto>> updateNotice(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable long noticeId,
+            @RequestBody NoticeUpdateRequestDto request
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        return ResponseEntity.ok(ApiResponse.ok(noticeService.updateNotice(memberId, noticeId, request)));
+    }
+
+    @DeleteMapping("/{noticeId}")
+    @Operation(summary = "공지사항 삭제", description = "관리자가 공지사항을 삭제합니다.")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.NOTICE_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable long noticeId
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        noticeService.deleteNotice(memberId, noticeId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/src/main/java/monochrome/libri/notice/controller/NoticeController.java
+++ b/src/main/java/monochrome/libri/notice/controller/NoticeController.java
@@ -1,0 +1,57 @@
+package monochrome.libri.notice.controller;
+
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.global.response.ApiResponse;
+import monochrome.libri.global.swagger.ApiErrorCodes;
+import monochrome.libri.notice.dto.response.NoticeDetailResponseDto;
+import monochrome.libri.notice.dto.response.NoticeListResponseDto;
+import monochrome.libri.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    public NoticeController(NoticeService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    @GetMapping
+    @Operation(summary = "공지사항 목록 조회", description = "공개된 공지사항 목록을 조회합니다.")
+    @ApiErrorCodes({
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<NoticeListResponseDto>> getNotices(
+            @Parameter(description = "페이지(0부터)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        if (page < 0 || size <= 0) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(ApiResponse.ok(noticeService.getPublishedNotices(pageable)));
+    }
+
+    @GetMapping("/{noticeId}")
+    @Operation(summary = "공지사항 상세 조회", description = "공개된 공지사항 상세를 조회합니다.")
+    @ApiErrorCodes({
+            ErrorCode.NOTICE_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<NoticeDetailResponseDto>> getNotice(@PathVariable long noticeId) {
+        return ResponseEntity.ok(ApiResponse.ok(noticeService.getPublishedNotice(noticeId)));
+    }
+}

--- a/src/main/java/monochrome/libri/notice/domain/Notice.java
+++ b/src/main/java/monochrome/libri/notice/domain/Notice.java
@@ -1,0 +1,53 @@
+package monochrome.libri.notice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import monochrome.libri.global.domain.AuditableEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notice extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id")
+    private long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, length = 5000)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean pinned;
+
+    @Column(nullable = false)
+    private boolean published;
+
+    public void update(String title, String content, Boolean pinned, Boolean published) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+        if (pinned != null) {
+            this.pinned = pinned;
+        }
+        if (published != null) {
+            this.published = published;
+        }
+    }
+}

--- a/src/main/java/monochrome/libri/notice/dto/request/NoticeCreateRequestDto.java
+++ b/src/main/java/monochrome/libri/notice/dto/request/NoticeCreateRequestDto.java
@@ -1,0 +1,13 @@
+package monochrome.libri.notice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NoticeCreateRequestDto(
+        @NotBlank(message = "공지사항 제목은 필수입니다.")
+        String title,
+        @NotBlank(message = "공지사항 내용은 필수입니다.")
+        String content,
+        Boolean pinned,
+        Boolean published
+) {
+}

--- a/src/main/java/monochrome/libri/notice/dto/request/NoticeUpdateRequestDto.java
+++ b/src/main/java/monochrome/libri/notice/dto/request/NoticeUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package monochrome.libri.notice.dto.request;
+
+public record NoticeUpdateRequestDto(
+        String title,
+        String content,
+        Boolean pinned,
+        Boolean published
+) {
+}

--- a/src/main/java/monochrome/libri/notice/dto/response/NoticeDetailResponseDto.java
+++ b/src/main/java/monochrome/libri/notice/dto/response/NoticeDetailResponseDto.java
@@ -1,0 +1,27 @@
+package monochrome.libri.notice.dto.response;
+
+import monochrome.libri.notice.domain.Notice;
+
+import java.time.LocalDateTime;
+
+public record NoticeDetailResponseDto(
+        long noticeId,
+        String title,
+        String content,
+        boolean pinned,
+        boolean published,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static NoticeDetailResponseDto from(Notice notice) {
+        return new NoticeDetailResponseDto(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.isPinned(),
+                notice.isPublished(),
+                notice.getCreatedDate(),
+                notice.getLastModifiedDate()
+        );
+    }
+}

--- a/src/main/java/monochrome/libri/notice/dto/response/NoticeListItemResponseDto.java
+++ b/src/main/java/monochrome/libri/notice/dto/response/NoticeListItemResponseDto.java
@@ -1,0 +1,11 @@
+package monochrome.libri.notice.dto.response;
+
+import java.time.LocalDateTime;
+
+public record NoticeListItemResponseDto(
+        long noticeId,
+        String title,
+        boolean pinned,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/monochrome/libri/notice/dto/response/NoticeListResponseDto.java
+++ b/src/main/java/monochrome/libri/notice/dto/response/NoticeListResponseDto.java
@@ -1,0 +1,11 @@
+package monochrome.libri.notice.dto.response;
+
+import java.util.List;
+
+public record NoticeListResponseDto(
+        List<NoticeListItemResponseDto> content,
+        boolean hasNext,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/monochrome/libri/notice/repository/NoticeRepository.java
+++ b/src/main/java/monochrome/libri/notice/repository/NoticeRepository.java
@@ -1,0 +1,13 @@
+package monochrome.libri.notice.repository;
+
+import monochrome.libri.notice.domain.Notice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    Slice<Notice> findByPublishedTrueOrderByPinnedDescCreatedDateDesc(Pageable pageable);
+    Optional<Notice> findByIdAndPublishedTrue(Long id);
+}

--- a/src/main/java/monochrome/libri/notice/service/NoticeService.java
+++ b/src/main/java/monochrome/libri/notice/service/NoticeService.java
@@ -1,0 +1,15 @@
+package monochrome.libri.notice.service;
+
+import monochrome.libri.notice.dto.request.NoticeCreateRequestDto;
+import monochrome.libri.notice.dto.request.NoticeUpdateRequestDto;
+import monochrome.libri.notice.dto.response.NoticeDetailResponseDto;
+import monochrome.libri.notice.dto.response.NoticeListResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface NoticeService {
+    NoticeListResponseDto getPublishedNotices(Pageable pageable);
+    NoticeDetailResponseDto getPublishedNotice(long noticeId);
+    NoticeDetailResponseDto createNotice(long memberId, NoticeCreateRequestDto request);
+    NoticeDetailResponseDto updateNotice(long memberId, long noticeId, NoticeUpdateRequestDto request);
+    void deleteNotice(long memberId, long noticeId);
+}

--- a/src/main/java/monochrome/libri/notice/service/impl/NoticeServiceImpl.java
+++ b/src/main/java/monochrome/libri/notice/service/impl/NoticeServiceImpl.java
@@ -1,0 +1,124 @@
+package monochrome.libri.notice.service.impl;
+
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.member.domain.Member;
+import monochrome.libri.member.domain.Role;
+import monochrome.libri.member.service.MemberService;
+import monochrome.libri.notice.domain.Notice;
+import monochrome.libri.notice.dto.request.NoticeCreateRequestDto;
+import monochrome.libri.notice.dto.request.NoticeUpdateRequestDto;
+import monochrome.libri.notice.dto.response.NoticeDetailResponseDto;
+import monochrome.libri.notice.dto.response.NoticeListItemResponseDto;
+import monochrome.libri.notice.dto.response.NoticeListResponseDto;
+import monochrome.libri.notice.repository.NoticeRepository;
+import monochrome.libri.notice.service.NoticeService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class NoticeServiceImpl implements NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final MemberService memberService;
+
+    public NoticeServiceImpl(NoticeRepository noticeRepository, MemberService memberService) {
+        this.noticeRepository = noticeRepository;
+        this.memberService = memberService;
+    }
+
+    @Override
+    public NoticeListResponseDto getPublishedNotices(Pageable pageable) {
+        Slice<Notice> slice = noticeRepository.findByPublishedTrueOrderByPinnedDescCreatedDateDesc(pageable);
+        List<NoticeListItemResponseDto> content = slice.getContent().stream()
+                .map(notice -> new NoticeListItemResponseDto(
+                        notice.getId(),
+                        notice.getTitle(),
+                        notice.isPinned(),
+                        notice.getCreatedDate()
+                ))
+                .toList();
+
+        return new NoticeListResponseDto(content, slice.hasNext(), slice.getNumber(), slice.getSize());
+    }
+
+    @Override
+    public NoticeDetailResponseDto getPublishedNotice(long noticeId) {
+        Notice notice = noticeRepository.findByIdAndPublishedTrue(noticeId)
+                .orElseThrow(() -> new LibriException(ErrorCode.NOTICE_NOT_FOUND));
+        return NoticeDetailResponseDto.from(notice);
+    }
+
+    @Override
+    @Transactional
+    public NoticeDetailResponseDto createNotice(long memberId, NoticeCreateRequestDto request) {
+        Member member = getAdminMember(memberId);
+        if (request == null || request.title() == null || request.title().isBlank()
+                || request.content() == null || request.content().isBlank()) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Notice notice = Notice.builder()
+                .title(request.title().trim())
+                .content(request.content().trim())
+                .pinned(Boolean.TRUE.equals(request.pinned()))
+                .published(request.published() == null || request.published())
+                .build();
+
+        return NoticeDetailResponseDto.from(noticeRepository.save(notice));
+    }
+
+    @Override
+    @Transactional
+    public NoticeDetailResponseDto updateNotice(long memberId, long noticeId, NoticeUpdateRequestDto request) {
+        getAdminMember(memberId);
+        if (request == null || isEmptyUpdate(request)) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new LibriException(ErrorCode.NOTICE_NOT_FOUND));
+
+        String title = request.title() == null ? null : request.title().trim();
+        String content = request.content() == null ? null : request.content().trim();
+        if ("".equals(title) || "".equals(content)) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        notice.update(title, content, request.pinned(), request.published());
+        return NoticeDetailResponseDto.from(notice);
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotice(long memberId, long noticeId) {
+        getAdminMember(memberId);
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new LibriException(ErrorCode.NOTICE_NOT_FOUND));
+        noticeRepository.delete(notice);
+    }
+
+    private boolean isEmptyUpdate(NoticeUpdateRequestDto request) {
+        return request.title() == null
+                && request.content() == null
+                && request.pinned() == null
+                && request.published() == null;
+    }
+
+    private Member getAdminMember(long memberId) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        Member member = memberService.getMemberById(memberId)
+                .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
+        if (member.getRole() != Role.ADMIN) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
+        return member;
+    }
+}

--- a/src/main/java/monochrome/libri/shelf/dto/response/ShelfDetailResponseDto.java
+++ b/src/main/java/monochrome/libri/shelf/dto/response/ShelfDetailResponseDto.java
@@ -12,6 +12,7 @@ public record ShelfDetailResponseDto(
             Long bookId,
             String title,
             String author,
+            String publisher,
             String coverUrl,
             java.time.LocalDate releaseDate
     ) {

--- a/src/main/java/monochrome/libri/shelf/dto/response/ShelfListItemResponseDto.java
+++ b/src/main/java/monochrome/libri/shelf/dto/response/ShelfListItemResponseDto.java
@@ -9,6 +9,7 @@ public record ShelfListItemResponseDto(
         long bookId,
         String title,
         String author,
+        String publisher,
         String coverUrl,
         ShelfStatus status,
         int progressPercent,

--- a/src/main/java/monochrome/libri/shelf/service/impl/ShelfServiceImpl.java
+++ b/src/main/java/monochrome/libri/shelf/service/impl/ShelfServiceImpl.java
@@ -180,7 +180,7 @@ public class ShelfServiceImpl implements ShelfService {
 
     private ShelfDetailResponseDto buildShelfDetail(Shelf shelf, long shelfId, Long memberId) {
         int totalPage = shelf.getBook().getTotalPage();
-        int currentPage = shelf.getCurrentPage() == null ? 0 : shelf.getCurrentPage();
+        int currentPage = resolveCurrentPage(shelf);
         int progressPercent = calculateProgressPercent(
                 shelf.getProgressType(),
                 shelf.getProgressValue(),
@@ -192,6 +192,7 @@ public class ShelfServiceImpl implements ShelfService {
                 shelf.getBook().getId(),
                 shelf.getBook().getTitle(),
                 shelf.getBook().getAuthor(),
+                shelf.getBook().getPublisher(),
                 shelf.getBook().getCoverImageUrl(),
                 shelf.getBook().getReleaseDate()
         );
@@ -276,7 +277,7 @@ public class ShelfServiceImpl implements ShelfService {
     }
 
     private ShelfListItemResponseDto toShelfListItem(Shelf shelf) {
-        int currentPage = shelf.getCurrentPage() == null ? 0 : shelf.getCurrentPage();
+        int currentPage = resolveCurrentPage(shelf);
         int progressPercent = calculateProgressPercent(
                 shelf.getProgressType(),
                 shelf.getProgressValue(),
@@ -289,11 +290,20 @@ public class ShelfServiceImpl implements ShelfService {
                 shelf.getBook().getId(),
                 shelf.getBook().getTitle(),
                 shelf.getBook().getAuthor(),
+                shelf.getBook().getPublisher(),
                 shelf.getBook().getCoverImageUrl(),
                 shelf.getStatus(),
                 progressPercent,
                 shelf.getStartDate(),
                 shelf.getEndDate()
         );
+    }
+
+    private int resolveCurrentPage(Shelf shelf) {
+        if (shelf.getProgressType() == monochrome.libri.shelf.domain.ShelfProgressType.PAGE
+                && shelf.getCurrentPage() == null) {
+            return shelf.getProgressValue();
+        }
+        return shelf.getCurrentPage() == null ? 0 : shelf.getCurrentPage();
     }
 }

--- a/src/test/java/monochrome/libri/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/monochrome/libri/follow/service/FollowServiceImplTest.java
@@ -3,16 +3,20 @@ package monochrome.libri.follow.service;
 import monochrome.libri.TestFixtures;
 import monochrome.libri.follow.domain.Follow;
 import monochrome.libri.follow.domain.FollowStatus;
+import monochrome.libri.follow.dto.MemberSummaryDto;
 import monochrome.libri.follow.repository.FollowRepository;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.service.MemberService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,5 +98,41 @@ class FollowServiceImplTest {
 
         assertThatThrownBy(() -> service.unfollow(1L, 2L))
                 .isInstanceOf(LibriException.class);
+    }
+
+    @Test
+    void findFollowers_returnsRepositorySlice() {
+        Member member = TestFixtures.member(1L);
+        var pageable = PageRequest.of(0, 20);
+        var expected = new SliceImpl<>(List.of(
+                new MemberSummaryDto(2L, "user2", "nick2", "/profile/2")
+        ), pageable, false);
+
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member));
+        when(followRepository.findFollowers(member, pageable)).thenReturn(expected);
+
+        var result = service.findFollowers(1L, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).memberId()).isEqualTo(2L);
+        verify(followRepository).findFollowers(member, pageable);
+    }
+
+    @Test
+    void findFollowings_returnsRepositorySlice() {
+        Member member = TestFixtures.member(1L);
+        var pageable = PageRequest.of(0, 20);
+        var expected = new SliceImpl<>(List.of(
+                new MemberSummaryDto(3L, "user3", "nick3", "/profile/3")
+        ), pageable, false);
+
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member));
+        when(followRepository.findFollowings(member, pageable)).thenReturn(expected);
+
+        var result = service.findFollowings(1L, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).memberId()).isEqualTo(3L);
+        verify(followRepository).findFollowings(member, pageable);
     }
 }

--- a/src/test/java/monochrome/libri/home/service/HomeServiceImplTest.java
+++ b/src/test/java/monochrome/libri/home/service/HomeServiceImplTest.java
@@ -1,6 +1,8 @@
 package monochrome.libri.home.service;
 
 import monochrome.libri.TestFixtures;
+import monochrome.libri.follow.domain.FollowStatus;
+import monochrome.libri.follow.repository.FollowRepository;
 import monochrome.libri.home.dto.response.HomeResponseDto;
 import monochrome.libri.home.service.impl.HomeServiceImpl;
 import monochrome.libri.member.domain.Member;
@@ -29,14 +31,17 @@ class HomeServiceImplTest {
     @Test
     void getHome_returnsAnonymousSummaryForNullMember() {
         MemberService memberService = mock(MemberService.class);
+        FollowRepository followRepository = mock(FollowRepository.class);
         ShelfRepository shelfRepository = mock(ShelfRepository.class);
         Clock clock = Clock.fixed(Instant.parse("2024-01-10T00:00:00Z"), ZoneOffset.UTC);
 
-        HomeServiceImpl service = new HomeServiceImpl(memberService, shelfRepository, clock);
+        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, clock);
 
         HomeResponseDto response = service.getHome(null);
 
         assertThat(response.me().memberId()).isNull();
+        assertThat(response.me().followerCount()).isZero();
+        assertThat(response.me().followingCount()).isZero();
         assertThat(response.shelfSummary().wantToReadCount()).isEqualTo(0);
         assertThat(response.readingBooks()).isEmpty();
     }
@@ -44,11 +49,14 @@ class HomeServiceImplTest {
     @Test
     void getHome_buildsReadingBooksAndCounts() {
         MemberService memberService = mock(MemberService.class);
+        FollowRepository followRepository = mock(FollowRepository.class);
         ShelfRepository shelfRepository = mock(ShelfRepository.class);
         Clock clock = Clock.fixed(Instant.parse("2024-01-10T00:00:00Z"), ZoneOffset.UTC);
 
         Member member = TestFixtures.member(1L);
         when(memberService.getMemberById(1L)).thenReturn(Optional.of(member));
+        when(followRepository.countByFollowingAndFollowStatus(member, FollowStatus.FOLLOW)).thenReturn(4L);
+        when(followRepository.countByFollowerAndFollowStatus(member, FollowStatus.FOLLOW)).thenReturn(7L);
         when(shelfRepository.findCountSummaryByMemberId(1L))
                 .thenReturn(new ShelfCountSummary(1, 2, 3));
 
@@ -70,13 +78,54 @@ class HomeServiceImplTest {
         when(shelfRepository.findShelfBooksByStatus(eq(1L), eq(ShelfStatus.FINISHED), eq(3)))
                 .thenReturn(List.of());
 
-        HomeServiceImpl service = new HomeServiceImpl(memberService, shelfRepository, clock);
+        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, clock);
         HomeResponseDto response = service.getHome(1L);
 
+        assertThat(response.me().followerCount()).isEqualTo(4);
+        assertThat(response.me().followingCount()).isEqualTo(7);
         assertThat(response.shelfSummary().wantToReadCount()).isEqualTo(1);
         assertThat(response.readingBooks()).hasSize(1);
         HomeResponseDto.ReadingBook book = response.readingBooks().get(0);
         assertThat(book.progressPercent()).isEqualTo(25);
         assertThat(book.readingDays()).isEqualTo(3);
+    }
+
+    @Test
+    void getHome_usesProgressValueWhenPageTypeAndCurrentPageIsNull() {
+        MemberService memberService = mock(MemberService.class);
+        FollowRepository followRepository = mock(FollowRepository.class);
+        ShelfRepository shelfRepository = mock(ShelfRepository.class);
+        Clock clock = Clock.fixed(Instant.parse("2024-01-10T00:00:00Z"), ZoneOffset.UTC);
+
+        Member member = TestFixtures.member(1L);
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member));
+        when(followRepository.countByFollowingAndFollowStatus(member, FollowStatus.FOLLOW)).thenReturn(0L);
+        when(followRepository.countByFollowerAndFollowStatus(member, FollowStatus.FOLLOW)).thenReturn(0L);
+        when(shelfRepository.findCountSummaryByMemberId(1L))
+                .thenReturn(new ShelfCountSummary(0, 1, 0));
+
+        ShelfBookRow readingRow = new ShelfBookRow(
+                10L,
+                20L,
+                "Title",
+                "/cover",
+                200,
+                null,
+                ShelfProgressType.PAGE,
+                50,
+                LocalDate.of(2024, 1, 8)
+        );
+        when(shelfRepository.findShelfBooksByStatus(eq(1L), eq(ShelfStatus.READING), eq(3)))
+                .thenReturn(List.of(readingRow));
+        when(shelfRepository.findShelfBooksByStatus(eq(1L), eq(ShelfStatus.WANT_TO_READ), eq(3)))
+                .thenReturn(List.of());
+        when(shelfRepository.findShelfBooksByStatus(eq(1L), eq(ShelfStatus.FINISHED), eq(3)))
+                .thenReturn(List.of());
+
+        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, clock);
+        HomeResponseDto response = service.getHome(1L);
+
+        assertThat(response.readingBooks()).hasSize(1);
+        assertThat(response.readingBooks().get(0).progressPercent()).isEqualTo(25);
     }
 }

--- a/src/test/java/monochrome/libri/inquiry/service/InquiryServiceImplTest.java
+++ b/src/test/java/monochrome/libri/inquiry/service/InquiryServiceImplTest.java
@@ -1,0 +1,163 @@
+package monochrome.libri.inquiry.service;
+
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.inquiry.domain.Inquiry;
+import monochrome.libri.inquiry.domain.InquiryStatus;
+import monochrome.libri.inquiry.dto.request.InquiryAnswerRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryCreateRequestDto;
+import monochrome.libri.inquiry.dto.request.InquiryStatusUpdateRequestDto;
+import monochrome.libri.inquiry.repository.InquiryRepository;
+import monochrome.libri.inquiry.service.impl.InquiryServiceImpl;
+import monochrome.libri.member.domain.Member;
+import monochrome.libri.member.domain.MemberStatus;
+import monochrome.libri.member.domain.Role;
+import monochrome.libri.member.domain.SignType;
+import monochrome.libri.member.service.MemberService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class InquiryServiceImplTest {
+
+    @Test
+    void createInquiry_savesPendingInquiry() {
+        InquiryRepository inquiryRepository = mock(InquiryRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        InquiryServiceImpl service = new InquiryServiceImpl(inquiryRepository, memberService);
+
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member(1L, Role.USER)));
+        when(inquiryRepository.save(any(Inquiry.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.createInquiry(1L, new InquiryCreateRequestDto(" title ", " content "));
+
+        ArgumentCaptor<Inquiry> captor = ArgumentCaptor.forClass(Inquiry.class);
+        verify(inquiryRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(InquiryStatus.PENDING);
+        assertThat(response.title()).isEqualTo("title");
+    }
+
+    @Test
+    void getInquiry_deniesOtherUser() {
+        InquiryRepository inquiryRepository = mock(InquiryRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        InquiryServiceImpl service = new InquiryServiceImpl(inquiryRepository, memberService);
+
+        Member owner = member(1L, Role.USER);
+        Member other = member(2L, Role.USER);
+        Inquiry inquiry = Inquiry.builder()
+                .id(10L)
+                .member(owner)
+                .title("title")
+                .content("content")
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        when(memberService.getMemberById(2L)).thenReturn(Optional.of(other));
+        when(inquiryRepository.findById(10L)).thenReturn(Optional.of(inquiry));
+
+        assertThatThrownBy(() -> service.getInquiry(10L, 2L))
+                .isInstanceOf(LibriException.class);
+    }
+
+    @Test
+    void answerInquiry_requiresAdminAndMarksAnswered() {
+        InquiryRepository inquiryRepository = mock(InquiryRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        InquiryServiceImpl service = new InquiryServiceImpl(inquiryRepository, memberService);
+
+        Member owner = member(1L, Role.USER);
+        Member admin = member(99L, Role.ADMIN);
+        Inquiry inquiry = Inquiry.builder()
+                .id(10L)
+                .member(owner)
+                .title("title")
+                .content("content")
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        when(memberService.getMemberById(99L)).thenReturn(Optional.of(admin));
+        when(inquiryRepository.findById(10L)).thenReturn(Optional.of(inquiry));
+
+        var response = service.answerInquiry(99L, 10L, new InquiryAnswerRequestDto(" answer "));
+
+        assertThat(response.status()).isEqualTo(InquiryStatus.ANSWERED);
+        assertThat(response.answerContent()).isEqualTo("answer");
+    }
+
+    @Test
+    void getAllInquiries_returnsContentForAdmin() {
+        InquiryRepository inquiryRepository = mock(InquiryRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        InquiryServiceImpl service = new InquiryServiceImpl(inquiryRepository, memberService);
+
+        Member owner = member(1L, Role.USER);
+        Member admin = member(99L, Role.ADMIN);
+        Inquiry inquiry = Inquiry.builder()
+                .id(10L)
+                .member(owner)
+                .title("title")
+                .content("content")
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        when(memberService.getMemberById(99L)).thenReturn(Optional.of(admin));
+        when(inquiryRepository.findAll(any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(inquiry), PageRequest.of(0, 20), 1));
+        when(inquiryRepository.count()).thenReturn(1L);
+
+        var response = service.getAllInquiries(99L, PageRequest.of(0, 20));
+
+        assertThat(response.totalCount()).isEqualTo(1L);
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).memberId()).isEqualTo(1L);
+    }
+
+    @Test
+    void updateInquiryStatus_changesStatus() {
+        InquiryRepository inquiryRepository = mock(InquiryRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        InquiryServiceImpl service = new InquiryServiceImpl(inquiryRepository, memberService);
+
+        Member owner = member(1L, Role.USER);
+        Member admin = member(99L, Role.ADMIN);
+        Inquiry inquiry = Inquiry.builder()
+                .id(10L)
+                .member(owner)
+                .title("title")
+                .content("content")
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        when(memberService.getMemberById(99L)).thenReturn(Optional.of(admin));
+        when(inquiryRepository.findById(10L)).thenReturn(Optional.of(inquiry));
+
+        var response = service.updateInquiryStatus(99L, 10L, new InquiryStatusUpdateRequestDto(InquiryStatus.CLOSED));
+
+        assertThat(response.status()).isEqualTo(InquiryStatus.CLOSED);
+    }
+
+    private Member member(long id, Role role) {
+        return Member.builder()
+                .id(id)
+                .provider(SignType.EMAIL)
+                .email("user" + id + "@test.com")
+                .emailVerified(true)
+                .nickname("nick" + id)
+                .username("user" + id)
+                .passwordHash("hash")
+                .privateAccount(false)
+                .memberStatus(MemberStatus.ACTIVE)
+                .role(role)
+                .build();
+    }
+}

--- a/src/test/java/monochrome/libri/notice/service/NoticeServiceImplTest.java
+++ b/src/test/java/monochrome/libri/notice/service/NoticeServiceImplTest.java
@@ -1,0 +1,97 @@
+package monochrome.libri.notice.service;
+
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.member.domain.Member;
+import monochrome.libri.member.domain.MemberStatus;
+import monochrome.libri.member.domain.Role;
+import monochrome.libri.member.domain.SignType;
+import monochrome.libri.member.service.MemberService;
+import monochrome.libri.notice.domain.Notice;
+import monochrome.libri.notice.dto.request.NoticeCreateRequestDto;
+import monochrome.libri.notice.dto.request.NoticeUpdateRequestDto;
+import monochrome.libri.notice.repository.NoticeRepository;
+import monochrome.libri.notice.service.impl.NoticeServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class NoticeServiceImplTest {
+
+    @Test
+    void createNotice_requiresAdmin() {
+        NoticeRepository noticeRepository = mock(NoticeRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        NoticeServiceImpl service = new NoticeServiceImpl(noticeRepository, memberService);
+
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member(1L, Role.USER)));
+
+        assertThatThrownBy(() -> service.createNotice(1L, new NoticeCreateRequestDto("title", "content", false, true)))
+                .isInstanceOf(LibriException.class);
+        verify(noticeRepository, never()).save(any());
+    }
+
+    @Test
+    void createNotice_savesTrimmedNotice() {
+        NoticeRepository noticeRepository = mock(NoticeRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        NoticeServiceImpl service = new NoticeServiceImpl(noticeRepository, memberService);
+
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member(1L, Role.ADMIN)));
+        when(noticeRepository.save(any(Notice.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.createNotice(1L, new NoticeCreateRequestDto(" title ", " content ", true, false));
+
+        ArgumentCaptor<Notice> captor = ArgumentCaptor.forClass(Notice.class);
+        verify(noticeRepository).save(captor.capture());
+        assertThat(captor.getValue().getTitle()).isEqualTo("title");
+        assertThat(captor.getValue().getContent()).isEqualTo("content");
+        assertThat(response.pinned()).isTrue();
+        assertThat(response.published()).isFalse();
+    }
+
+    @Test
+    void updateNotice_updatesFields() {
+        NoticeRepository noticeRepository = mock(NoticeRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        NoticeServiceImpl service = new NoticeServiceImpl(noticeRepository, memberService);
+
+        Notice notice = Notice.builder()
+                .id(10L)
+                .title("old")
+                .content("old-content")
+                .pinned(false)
+                .published(true)
+                .build();
+
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member(1L, Role.ADMIN)));
+        when(noticeRepository.findById(10L)).thenReturn(Optional.of(notice));
+
+        var response = service.updateNotice(1L, 10L, new NoticeUpdateRequestDto("new", "new-content", true, false));
+
+        assertThat(response.title()).isEqualTo("new");
+        assertThat(response.content()).isEqualTo("new-content");
+        assertThat(response.pinned()).isTrue();
+        assertThat(response.published()).isFalse();
+    }
+
+    private Member member(long id, Role role) {
+        return Member.builder()
+                .id(id)
+                .provider(SignType.EMAIL)
+                .email("user" + id + "@test.com")
+                .emailVerified(true)
+                .nickname("nick" + id)
+                .username("user" + id)
+                .passwordHash("hash")
+                .privateAccount(false)
+                .memberStatus(MemberStatus.ACTIVE)
+                .role(role)
+                .build();
+    }
+}

--- a/src/test/java/monochrome/libri/shelf/service/ShelfServiceImplTest.java
+++ b/src/test/java/monochrome/libri/shelf/service/ShelfServiceImplTest.java
@@ -94,6 +94,7 @@ class ShelfServiceImplTest {
         assertThat(response.totalCount()).isEqualTo(1L);
         assertThat(response.content()).hasSize(1);
         assertThat(response.content().get(0).bookId()).isEqualTo(2L);
+        assertThat(response.content().get(0).publisher()).isEqualTo("publisher2");
         assertThat(response.content().get(0).progressPercent()).isEqualTo(20);
     }
 
@@ -171,7 +172,44 @@ class ShelfServiceImplTest {
 
         var response = service.updateShelf(3L, 1L, dto);
 
+        assertThat(response.book().publisher()).isEqualTo("publisher2");
         assertThat(response.reading().status()).isEqualTo(ShelfStatus.FINISHED);
         assertThat(response.reading().progressPercent()).isEqualTo(100);
+    }
+
+    @Test
+    void getShelvesByStatus_usesProgressValueWhenPageTypeAndCurrentPageIsNull() {
+        ShelfRepository shelfRepository = mock(ShelfRepository.class);
+        ReviewService reviewService = mock(ReviewService.class);
+        MemberService memberService = mock(MemberService.class);
+        BookRepository bookRepository = mock(BookRepository.class);
+        Clock clock = Clock.systemUTC();
+        ShelfServiceImpl service = new ShelfServiceImpl(shelfRepository, reviewService, memberService, bookRepository, clock);
+
+        Member member = TestFixtures.member(1L);
+        Book book = TestFixtures.book(2L, 200);
+        Shelf shelf = Shelf.builder()
+                .id(3L)
+                .member(member)
+                .book(book)
+                .status(ShelfStatus.READING)
+                .progressType(ShelfProgressType.PAGE)
+                .progressValue(40)
+                .currentPage(null)
+                .startDate(LocalDate.of(2024, 1, 1))
+                .build();
+
+        when(shelfRepository.findByMemberIdAndStatusOrderByCreatedDateDesc(eq(1L), eq(ShelfStatus.READING), any()))
+                .thenReturn(new org.springframework.data.domain.SliceImpl<>(
+                        java.util.List.of(shelf),
+                        org.springframework.data.domain.PageRequest.of(0, 10),
+                        false
+                ));
+        when(shelfRepository.countByMemberIdAndStatus(1L, ShelfStatus.READING)).thenReturn(1L);
+
+        var response = service.getShelvesByStatus(1L, ShelfStatus.READING, org.springframework.data.domain.PageRequest.of(0, 10));
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).progressPercent()).isEqualTo(20);
     }
 }


### PR DESCRIPTION
  - 공지사항 도메인, 저장소, 서비스, 컨트롤러 및 관리자 CRUD API 추가
  - 문의하기 도메인, 저장소, 서비스, 컨트롤러 및 관리자 답변/상태 변경 API 추가
  - 공지사항/문의하기 예외 코드 및 서비스 테스트 추가
  - API 개요 문서에 공지사항/문의하기 스펙 반영
  - 홈, 서재, 팔로우, 독서 진도 관련 응답 누락 및 계산 로직 보완