### PR TITLE
fix: 내 정보 조회 API 추가

### DIFF
--- a/src/main/java/monochrome/libri/member/controller/MemberController.java
+++ b/src/main/java/monochrome/libri/member/controller/MemberController.java
@@ -27,6 +27,27 @@ public class MemberController {
         this.memberService = memberService;
     }
 
+    @GetMapping("/me")
+    @Operation(
+            summary = "내 정보 조회",
+            description = "액세스 토큰으로 로그인한 회원의 정보를 조회합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.MEMBER_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<MemberResponseDto>> getMe(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        var member = memberService.getMemberById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
+        return ResponseEntity.ok(ApiResponse.ok(MemberResponseDto.from(member)));
+    }
+
     /**
      * 회원 탈퇴 (현재 로그인한 사용자 기준)
      * DELETE /api/v1/auth/me

--- a/src/test/java/monochrome/libri/member/controller/MemberControllerTest.java
+++ b/src/test/java/monochrome/libri/member/controller/MemberControllerTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,6 +30,27 @@ class MemberControllerTest {
 
     @InjectMocks
     private MemberController controller;
+
+    @Test
+    void getMe_requiresAuth() {
+        assertThatThrownBy(() -> controller.getMe(null))
+                .isInstanceOf(LibriException.class);
+        verifyNoInteractions(memberService);
+    }
+
+    @Test
+    void getMe_returnsAuthenticatedMember() {
+        UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
+        Member member = TestFixtures.member(1L);
+
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member));
+
+        var response = controller.getMe(principal);
+
+        verify(memberService).getMemberById(1L);
+        assertThat(response.getBody().data().id()).isEqualTo(1L);
+        assertThat(response.getBody().data().email()).isEqualTo(member.getEmail());
+    }
 
     @Test
     void updateNickname_requiresAuth() {


### PR DESCRIPTION
  - 'GET /api/v1/members/me' 엔드포인트 추가
  - 엑세스 토큰 기반으로 로그인한 회원 정보 반환