### PR TITLE
20260421 merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 ext {
 	querydslVersion = "5.0.0"
+	awsSdkVersion = "2.30.31"
 }
 
 dependencies {
@@ -63,6 +64,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	implementation platform("software.amazon.awssdk:bom:${awsSdkVersion}")
+	implementation 'software.amazon.awssdk:s3'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/monochrome/libri/block/domain/MemberBlock.java
+++ b/src/main/java/monochrome/libri/block/domain/MemberBlock.java
@@ -1,0 +1,48 @@
+package monochrome.libri.block.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import monochrome.libri.global.domain.AuditableEntity;
+import monochrome.libri.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "member_block",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_member_block_blocker_blocked",
+                        columnNames = {"blocker_member_id", "blocked_member_id"}
+                )
+        }
+)
+public class MemberBlock extends AuditableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_block_id")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_member_id", nullable = false)
+    private Member blocker;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_member_id", nullable = false)
+    private Member blocked;
+}

--- a/src/main/java/monochrome/libri/block/dto/response/BlockedMemberItemResponseDto.java
+++ b/src/main/java/monochrome/libri/block/dto/response/BlockedMemberItemResponseDto.java
@@ -1,0 +1,23 @@
+package monochrome.libri.block.dto.response;
+
+import monochrome.libri.block.domain.MemberBlock;
+
+import java.time.LocalDateTime;
+
+public record BlockedMemberItemResponseDto(
+        long memberId,
+        String username,
+        String nickname,
+        String profilePath,
+        LocalDateTime blockedAt
+) {
+    public static BlockedMemberItemResponseDto from(MemberBlock memberBlock) {
+        return new BlockedMemberItemResponseDto(
+                memberBlock.getBlocked().getId(),
+                memberBlock.getBlocked().getUsername(),
+                memberBlock.getBlocked().getNickname(),
+                memberBlock.getBlocked().getProfilePath(),
+                memberBlock.getCreatedDate()
+        );
+    }
+}

--- a/src/main/java/monochrome/libri/block/dto/response/BlockedMemberListResponseDto.java
+++ b/src/main/java/monochrome/libri/block/dto/response/BlockedMemberListResponseDto.java
@@ -1,0 +1,15 @@
+package monochrome.libri.block.dto.response;
+
+import java.util.List;
+
+public record BlockedMemberListResponseDto(
+        long totalCount,
+        List<BlockedMemberItemResponseDto> content,
+        boolean hasNext,
+        int page,
+        int size
+) {
+    public static BlockedMemberListResponseDto empty(int page, int size) {
+        return new BlockedMemberListResponseDto(0L, List.of(), false, page, size);
+    }
+}

--- a/src/main/java/monochrome/libri/block/repository/MemberBlockRepository.java
+++ b/src/main/java/monochrome/libri/block/repository/MemberBlockRepository.java
@@ -1,0 +1,25 @@
+package monochrome.libri.block.repository;
+
+import monochrome.libri.block.domain.MemberBlock;
+import monochrome.libri.member.domain.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberBlockRepository extends JpaRepository<MemberBlock, Long> {
+    boolean existsByBlockerAndBlocked(Member blocker, Member blocked);
+
+    boolean existsByBlockerIdAndBlockedId(long blockerId, long blockedId);
+
+    Optional<MemberBlock> findByBlockerAndBlocked(Member blocker, Member blocked);
+
+    @EntityGraph(attributePaths = {"blocked"})
+    Slice<MemberBlock> findByBlockerIdOrderByCreatedDateDesc(long blockerId, Pageable pageable);
+
+    long countByBlockerId(long blockerId);
+}

--- a/src/main/java/monochrome/libri/block/service/BlockService.java
+++ b/src/main/java/monochrome/libri/block/service/BlockService.java
@@ -1,0 +1,11 @@
+package monochrome.libri.block.service;
+
+import monochrome.libri.block.dto.response.BlockedMemberListResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface BlockService {
+    void blockMember(long blockerMemberId, long blockedMemberId);
+    void unblockMember(long blockerMemberId, long blockedMemberId);
+    BlockedMemberListResponseDto getBlockedMembers(long blockerMemberId, Pageable pageable);
+    boolean hasBlockRelation(long memberId, long otherMemberId);
+}

--- a/src/main/java/monochrome/libri/block/service/impl/BlockServiceImpl.java
+++ b/src/main/java/monochrome/libri/block/service/impl/BlockServiceImpl.java
@@ -1,0 +1,103 @@
+package monochrome.libri.block.service.impl;
+
+import monochrome.libri.block.domain.MemberBlock;
+import monochrome.libri.block.dto.response.BlockedMemberItemResponseDto;
+import monochrome.libri.block.dto.response.BlockedMemberListResponseDto;
+import monochrome.libri.block.repository.MemberBlockRepository;
+import monochrome.libri.block.service.BlockService;
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.member.domain.Member;
+import monochrome.libri.member.repository.MemberRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class BlockServiceImpl implements BlockService {
+
+    private final MemberBlockRepository memberBlockRepository;
+    private final MemberRepository memberRepository;
+
+    public BlockServiceImpl(MemberBlockRepository memberBlockRepository, MemberRepository memberRepository) {
+        this.memberBlockRepository = memberBlockRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    @Transactional
+    public void blockMember(long blockerMemberId, long blockedMemberId) {
+        validateNotSelf(blockerMemberId, blockedMemberId);
+
+        Member blocker = getMember(blockerMemberId);
+        Member blocked = getMember(blockedMemberId);
+
+        if (memberBlockRepository.existsByBlockerAndBlocked(blocker, blocked)) {
+            throw new LibriException(ErrorCode.BLOCK_ALREADY_EXISTS);
+        }
+
+        memberBlockRepository.save(MemberBlock.builder()
+                .blocker(blocker)
+                .blocked(blocked)
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void unblockMember(long blockerMemberId, long blockedMemberId) {
+        validateNotSelf(blockerMemberId, blockedMemberId);
+
+        Member blocker = getMember(blockerMemberId);
+        Member blocked = getMember(blockedMemberId);
+        MemberBlock memberBlock = memberBlockRepository.findByBlockerAndBlocked(blocker, blocked)
+                .orElseThrow(() -> new LibriException(ErrorCode.BLOCK_NOT_FOUND));
+
+        memberBlockRepository.delete(memberBlock);
+    }
+
+    @Override
+    public BlockedMemberListResponseDto getBlockedMembers(long blockerMemberId, Pageable pageable) {
+        if (blockerMemberId <= 0) {
+            return BlockedMemberListResponseDto.empty(pageable.getPageNumber(), pageable.getPageSize());
+        }
+
+        getMember(blockerMemberId);
+        Slice<MemberBlock> slice = memberBlockRepository.findByBlockerIdOrderByCreatedDateDesc(blockerMemberId, pageable);
+        List<BlockedMemberItemResponseDto> content = slice.getContent().stream()
+                .map(BlockedMemberItemResponseDto::from)
+                .toList();
+
+        return new BlockedMemberListResponseDto(
+                memberBlockRepository.countByBlockerId(blockerMemberId),
+                content,
+                slice.hasNext(),
+                slice.getNumber(),
+                slice.getSize()
+        );
+    }
+
+    @Override
+    public boolean hasBlockRelation(long memberId, long otherMemberId) {
+        if (memberId <= 0 || otherMemberId <= 0) {
+            return false;
+        }
+
+        return memberBlockRepository.existsByBlockerIdAndBlockedId(memberId, otherMemberId)
+                || memberBlockRepository.existsByBlockerIdAndBlockedId(otherMemberId, memberId);
+    }
+
+    private Member getMember(long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateNotSelf(long blockerMemberId, long blockedMemberId) {
+        if (blockerMemberId == blockedMemberId) {
+            throw new LibriException(ErrorCode.SELF_BLOCK_NOT_ALLOWED);
+        }
+    }
+}

--- a/src/main/java/monochrome/libri/book/dto/response/BookDetailResponseDto.java
+++ b/src/main/java/monochrome/libri/book/dto/response/BookDetailResponseDto.java
@@ -13,6 +13,7 @@ public record BookDetailResponseDto(
         String author,
         String publisher,
         LocalDate releaseDate,
+        int totalPage,
         String coverUrl,
         String introduction,
         ShelfInfo shelf,

--- a/src/main/java/monochrome/libri/book/repository/BookRepositoryCustom.java
+++ b/src/main/java/monochrome/libri/book/repository/BookRepositoryCustom.java
@@ -4,6 +4,9 @@ import monochrome.libri.book.domain.Book;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 public interface BookRepositoryCustom {
     Slice<Book> searchByKeyword(String textKeyword, Pageable pageable);
+    List<Book> findRecommendedBooks(Long memberId, int limit);
 }

--- a/src/main/java/monochrome/libri/book/repository/BookRepositoryCustomImpl.java
+++ b/src/main/java/monochrome/libri/book/repository/BookRepositoryCustomImpl.java
@@ -4,9 +4,13 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import monochrome.libri.book.domain.Book;
 import monochrome.libri.book.domain.QBook;
+import monochrome.libri.review.domain.QReview;
+import monochrome.libri.review.domain.ReviewStatus;
+import monochrome.libri.shelf.domain.QShelf;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -69,5 +73,29 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom{
         }
 
         return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    @Override
+    public List<Book> findRecommendedBooks(Long memberId, int limit) {
+        QBook b = QBook.book;
+        QReview r = QReview.review;
+        QShelf s = QShelf.shelf;
+
+        BooleanExpression exclusion = memberId == null || memberId <= 0
+                ? null
+                : b.id.notIn(
+                        JPAExpressions.select(s.book.id)
+                                .from(s)
+                                .where(s.member.id.eq(memberId))
+                );
+
+        return queryFactory
+                .selectFrom(b)
+                .leftJoin(r).on(r.book.eq(b).and(r.status.eq(ReviewStatus.ACTIVE)))
+                .where(exclusion)
+                .groupBy(b.id)
+                .orderBy(r.id.count().desc(), b.createdDate.desc(), b.id.desc())
+                .limit(limit)
+                .fetch();
     }
 }

--- a/src/main/java/monochrome/libri/book/service/impl/BookServiceImpl.java
+++ b/src/main/java/monochrome/libri/book/service/impl/BookServiceImpl.java
@@ -134,6 +134,7 @@ public class BookServiceImpl implements BookService {
                 book.getAuthor(),
                 book.getPublisher(),
                 book.getReleaseDate(),
+                book.getTotalPage(),
                 book.getCoverImageUrl(),
                 book.getIntroduction(),
                 shelfInfo,

--- a/src/main/java/monochrome/libri/comment/controller/NoteCommentController.java
+++ b/src/main/java/monochrome/libri/comment/controller/NoteCommentController.java
@@ -2,6 +2,7 @@ package monochrome.libri.comment.controller;
 
 import jakarta.validation.Valid;
 import monochrome.libri.comment.dto.request.CommentCreateRequestDto;
+import monochrome.libri.comment.dto.request.CommentReportCreateRequestDto;
 import monochrome.libri.comment.dto.response.CommentSliceResponseDto;
 import monochrome.libri.comment.service.NoteCommentService;
 import monochrome.libri.global.exception.ErrorCode;
@@ -83,6 +84,30 @@ public class NoteCommentController {
     ) {
         long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
         commentService.createComment(noteId, memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok());
+    }
+
+    @PostMapping("/{commentId}/reports")
+    @Operation(
+            summary = "노트 댓글 신고",
+            description = "댓글을 신고합니다. 같은 댓글은 한 번만 신고할 수 있습니다."
+    )
+    @SecurityRequirement(name = "BearerAuth")
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.COMMENT_NOT_FOUND,
+            ErrorCode.COMMENT_REPORT_ALREADY_EXISTS,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<Void>> reportComment(
+            @PathVariable long noteId,
+            @PathVariable long commentId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody CommentReportCreateRequestDto request
+    ) {
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        commentService.reportComment(noteId, commentId, memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok());
     }
 

--- a/src/main/java/monochrome/libri/comment/domain/CommentReportReason.java
+++ b/src/main/java/monochrome/libri/comment/domain/CommentReportReason.java
@@ -1,0 +1,9 @@
+package monochrome.libri.comment.domain;
+
+public enum CommentReportReason {
+    SPAM,
+    ABUSE,
+    SEXUAL_CONTENT,
+    FALSE_INFORMATION,
+    OTHER
+}

--- a/src/main/java/monochrome/libri/comment/domain/NoteCommentReport.java
+++ b/src/main/java/monochrome/libri/comment/domain/NoteCommentReport.java
@@ -1,0 +1,57 @@
+package monochrome.libri.comment.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import monochrome.libri.global.domain.AuditableEntity;
+import monochrome.libri.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "note_comment_report",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_note_comment_report_comment_reporter",
+                        columnNames = {"note_comment_id", "reporter_member_id"}
+                )
+        }
+)
+public class NoteCommentReport extends AuditableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "note_comment_report_id")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "note_comment_id", nullable = false)
+    private NoteComment noteComment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_member_id", nullable = false)
+    private Member reporter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private CommentReportReason reason;
+
+    @Column(length = 300)
+    private String detail;
+}

--- a/src/main/java/monochrome/libri/comment/dto/request/CommentReportCreateRequestDto.java
+++ b/src/main/java/monochrome/libri/comment/dto/request/CommentReportCreateRequestDto.java
@@ -1,0 +1,13 @@
+package monochrome.libri.comment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import monochrome.libri.comment.domain.CommentReportReason;
+
+public record CommentReportCreateRequestDto(
+        @NotNull(message = "신고 사유는 필수입니다.")
+        CommentReportReason reason,
+        @Size(max = 300, message = "상세 설명은 300자 이하여야 합니다.")
+        String detail
+) {
+}

--- a/src/main/java/monochrome/libri/comment/repository/NoteCommentReportRepository.java
+++ b/src/main/java/monochrome/libri/comment/repository/NoteCommentReportRepository.java
@@ -1,0 +1,12 @@
+package monochrome.libri.comment.repository;
+
+import monochrome.libri.comment.domain.NoteComment;
+import monochrome.libri.comment.domain.NoteCommentReport;
+import monochrome.libri.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoteCommentReportRepository extends JpaRepository<NoteCommentReport, Long> {
+    boolean existsByNoteCommentAndReporter(NoteComment noteComment, Member reporter);
+}

--- a/src/main/java/monochrome/libri/comment/repository/NoteCommentRepository.java
+++ b/src/main/java/monochrome/libri/comment/repository/NoteCommentRepository.java
@@ -22,6 +22,9 @@ public interface NoteCommentRepository extends JpaRepository<NoteComment, Long> 
 
     Optional<NoteComment> findByIdAndNoteId(long commentId, long noteId);
 
+    @EntityGraph(attributePaths = {"note", "note.member", "member"})
+    Optional<NoteComment> findWithNoteAndMemberByIdAndNoteId(long commentId, long noteId);
+
     @Query("select nc.note.id as noteId, count(nc) as count " +
             "from NoteComment nc where nc.note.id in :noteIds group by nc.note.id")
     List<NoteCommentCountRow> countByNoteIds(@Param("noteIds") Collection<Long> noteIds);

--- a/src/main/java/monochrome/libri/comment/service/NoteCommentService.java
+++ b/src/main/java/monochrome/libri/comment/service/NoteCommentService.java
@@ -1,12 +1,14 @@
 package monochrome.libri.comment.service;
 
 import monochrome.libri.comment.dto.request.CommentCreateRequestDto;
+import monochrome.libri.comment.dto.request.CommentReportCreateRequestDto;
 import monochrome.libri.comment.dto.response.CommentSliceResponseDto;
 import monochrome.libri.comment.dto.response.MyCommentListResponseDto;
 import org.springframework.data.domain.Pageable;
 
 public interface NoteCommentService {
     void createComment(long noteId, long memberId, CommentCreateRequestDto request);
+    void reportComment(long noteId, long commentId, long memberId, CommentReportCreateRequestDto request);
     CommentSliceResponseDto getComments(long noteId, long memberId, Pageable pageable);
     void deleteComment(long noteId, long commentId, long memberId);
     MyCommentListResponseDto getCommentsByMember(long memberId, Pageable pageable);

--- a/src/main/java/monochrome/libri/comment/service/impl/NoteCommentServiceImpl.java
+++ b/src/main/java/monochrome/libri/comment/service/impl/NoteCommentServiceImpl.java
@@ -1,11 +1,15 @@
 package monochrome.libri.comment.service.impl;
 
+import monochrome.libri.block.service.BlockService;
 import monochrome.libri.comment.domain.NoteComment;
+import monochrome.libri.comment.domain.NoteCommentReport;
 import monochrome.libri.comment.dto.request.CommentCreateRequestDto;
+import monochrome.libri.comment.dto.request.CommentReportCreateRequestDto;
 import monochrome.libri.comment.dto.response.CommentResponseDto;
 import monochrome.libri.comment.dto.response.CommentSliceResponseDto;
 import monochrome.libri.comment.dto.response.MyCommentItemResponseDto;
 import monochrome.libri.comment.dto.response.MyCommentListResponseDto;
+import monochrome.libri.comment.repository.NoteCommentReportRepository;
 import monochrome.libri.comment.repository.NoteCommentRepository;
 import monochrome.libri.comment.service.NoteCommentService;
 import monochrome.libri.global.exception.ErrorCode;
@@ -26,17 +30,23 @@ import java.util.List;
 public class NoteCommentServiceImpl implements NoteCommentService {
 
     private final NoteCommentRepository commentRepository;
+    private final NoteCommentReportRepository commentReportRepository;
     private final NoteRepository noteRepository;
     private final MemberService memberService;
+    private final BlockService blockService;
 
     public NoteCommentServiceImpl(
             NoteCommentRepository commentRepository,
+            NoteCommentReportRepository commentReportRepository,
             NoteRepository noteRepository,
-            MemberService memberService
+            MemberService memberService,
+            BlockService blockService
     ) {
         this.commentRepository = commentRepository;
+        this.commentReportRepository = commentReportRepository;
         this.noteRepository = noteRepository;
         this.memberService = memberService;
+        this.blockService = blockService;
     }
 
     @Override
@@ -55,6 +65,9 @@ public class NoteCommentServiceImpl implements NoteCommentService {
         if (note.isSecret()) {
             throw new LibriException(ErrorCode.ACCESS_DENIED);
         }
+        if (blockService.hasBlockRelation(memberId, note.getMember().getId())) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
 
         Member member = memberService.getMemberById(memberId)
                 .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
@@ -69,11 +82,47 @@ public class NoteCommentServiceImpl implements NoteCommentService {
     }
 
     @Override
+    @Transactional
+    public void reportComment(long noteId, long commentId, long memberId, CommentReportCreateRequestDto request) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        if (request == null || request.reason() == null) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        NoteComment comment = commentRepository.findWithNoteAndMemberByIdAndNoteId(commentId, noteId)
+                .orElseThrow(() -> new LibriException(ErrorCode.COMMENT_NOT_FOUND));
+        if (blockService.hasBlockRelation(memberId, comment.getMember().getId())
+                || blockService.hasBlockRelation(memberId, comment.getNote().getMember().getId())) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
+        Member reporter = memberService.getMemberById(memberId)
+                .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (commentReportRepository.existsByNoteCommentAndReporter(comment, reporter)) {
+            throw new LibriException(ErrorCode.COMMENT_REPORT_ALREADY_EXISTS);
+        }
+
+        NoteCommentReport report = NoteCommentReport.builder()
+                .noteComment(comment)
+                .reporter(reporter)
+                .reason(request.reason())
+                .detail(trimToNull(request.detail()))
+                .build();
+
+        commentReportRepository.save(report);
+    }
+
+    @Override
     public CommentSliceResponseDto getComments(long noteId, long memberId, Pageable pageable) {
         Note note = noteRepository.findWithMemberById(noteId)
                 .orElseThrow(() -> new LibriException(ErrorCode.NOTE_NOT_FOUND));
 
         boolean isOwner = memberId > 0 && note.getMember().getId() == memberId;
+        if (!isOwner && blockService.hasBlockRelation(memberId, note.getMember().getId())) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
         if (note.isSecret() && !isOwner) {
             throw new LibriException(ErrorCode.ACCESS_DENIED);
         }
@@ -146,5 +195,13 @@ public class NoteCommentServiceImpl implements NoteCommentService {
                 slice.getNumber(),
                 slice.getSize()
         );
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/monochrome/libri/follow/service/FollowServiceImpl.java
+++ b/src/main/java/monochrome/libri/follow/service/FollowServiceImpl.java
@@ -1,5 +1,6 @@
 package monochrome.libri.follow.service;
 
+import monochrome.libri.block.service.BlockService;
 import lombok.extern.slf4j.Slf4j;
 import monochrome.libri.follow.domain.Follow;
 import monochrome.libri.follow.domain.FollowStatus;
@@ -21,10 +22,12 @@ public class FollowServiceImpl implements FollowService{
 
     private final FollowRepository followRepository;
     private final MemberService memberService;
+    private final BlockService blockService;
 
-    public FollowServiceImpl(FollowRepository followRepository, MemberService memberService) {
+    public FollowServiceImpl(FollowRepository followRepository, MemberService memberService, BlockService blockService) {
         this.followRepository = followRepository;
         this.memberService = memberService;
+        this.blockService = blockService;
     }
 
     // ************* 내부 메서드 *************
@@ -56,6 +59,9 @@ public class FollowServiceImpl implements FollowService{
     @Transactional
     public void follow(Long followerMemberId, Long followingMemberId) {
         validateNotSelf(followerMemberId, followingMemberId);
+        if (blockService.hasBlockRelation(followerMemberId, followingMemberId)) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
 
         Member follower = getMemberOrThrow(followerMemberId);
         Member following = getMemberOrThrow(followingMemberId);

--- a/src/main/java/monochrome/libri/global/exception/ErrorCode.java
+++ b/src/main/java/monochrome/libri/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     // 공통
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 에러가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C002", "잘못된 요청입니다."),
+    S3_CONFIGURATION_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "S3 설정이 누락되었습니다."),
 
     // 인증/인가 관련
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "A001", "인증에 실패했습니다."),
@@ -26,6 +27,7 @@ public enum ErrorCode {
     SHELF_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "책장 정보를 찾을 수 없습니다."),
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "노트를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "N002", "댓글을 찾을 수 없습니다."),
+    COMMENT_REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "N003", "이미 신고한 댓글입니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "공지사항을 찾을 수 없습니다."),
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "문의 내역을 찾을 수 없습니다."),
@@ -34,7 +36,12 @@ public enum ErrorCode {
     EXIST_FOLLOW_RELATION(HttpStatus.CONFLICT, "F001", "이미 팔로우한 회원입니다."),
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "F002", "자기 자신은 팔로우할 수 없습니다."),
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "F003", "팔로우 관계를 찾을 수 없습니다."),
-    ALREADY_UNFOLLOWED(HttpStatus.BAD_REQUEST, "F004", "이미 언팔로우한 상태입니다.")
+    ALREADY_UNFOLLOWED(HttpStatus.BAD_REQUEST, "F004", "이미 언팔로우한 상태입니다."),
+
+    // 차단
+    BLOCK_ALREADY_EXISTS(HttpStatus.CONFLICT, "K001", "이미 차단한 회원입니다."),
+    SELF_BLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "K002", "자기 자신은 차단할 수 없습니다."),
+    BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "K003", "차단 관계를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/monochrome/libri/home/service/impl/HomeServiceImpl.java
+++ b/src/main/java/monochrome/libri/home/service/impl/HomeServiceImpl.java
@@ -1,5 +1,7 @@
 package monochrome.libri.home.service.impl;
 
+import monochrome.libri.book.domain.Book;
+import monochrome.libri.book.repository.BookRepository;
 import monochrome.libri.follow.domain.FollowStatus;
 import monochrome.libri.follow.repository.FollowRepository;
 import monochrome.libri.global.exception.ErrorCode;
@@ -25,37 +27,38 @@ import java.util.List;
 public class HomeServiceImpl implements HomeService {
 
     private static final int HOME_BOOK_PREVIEW_LIMIT = 3;
+    private static final int HOME_RECOMMENDATION_LIMIT = 3;
 
     private final MemberService memberService;
     private final FollowRepository followRepository;
     private final ShelfRepository shelfRepository;
+    private final BookRepository bookRepository;
     private final Clock clock;
 
     public HomeServiceImpl(
             MemberService memberService,
             FollowRepository followRepository,
             ShelfRepository shelfRepository,
+            BookRepository bookRepository,
             Clock clock
     ) {
         this.memberService = memberService;
         this.followRepository = followRepository;
         this.shelfRepository = shelfRepository;
+        this.bookRepository = bookRepository;
         this.clock = clock;
     }
 
     @Override
     public HomeResponseDto getHome(Long memberId) {
-        // 사용자 요약
-        HomeResponseDto.MeSummary me = buildMeSummary(memberId);
-
         HomeResponseDto.ShelfSummary shelfSummary = buildShelfSummary(memberId);
+        HomeResponseDto.MeSummary me = buildMeSummary(memberId, shelfSummary);
 
         List<HomeResponseDto.ReadingBook> readingBooks = buildReadingBooks(memberId);
         List<HomeResponseDto.BookSummary> wantToReadBooks = buildBookSummaries(memberId, ShelfStatus.WANT_TO_READ);
         List<HomeResponseDto.BookSummary> finishedBooks = buildBookSummaries(memberId, ShelfStatus.FINISHED);
 
-        // TODO: 도서 추천 로직 구현 예정
-        List<HomeResponseDto.BookRecommendation> recommendations = List.of();
+        List<HomeResponseDto.BookRecommendation> recommendations = buildRecommendations(memberId);
 
         return new HomeResponseDto(
                 me,
@@ -67,7 +70,7 @@ public class HomeServiceImpl implements HomeService {
         );
     }
 
-    private HomeResponseDto.MeSummary buildMeSummary(Long memberId) {
+    private HomeResponseDto.MeSummary buildMeSummary(Long memberId, HomeResponseDto.ShelfSummary shelfSummary) {
         if (memberId == null) {
             return new HomeResponseDto.MeSummary(null, null, null, 0, 0, 0);
         }
@@ -77,14 +80,17 @@ public class HomeServiceImpl implements HomeService {
         long followerCount = followRepository.countByFollowingAndFollowStatus(member, FollowStatus.FOLLOW);
         long followingCount = followRepository.countByFollowerAndFollowStatus(member, FollowStatus.FOLLOW);
 
-        // TODO: 현재 알림 기능이 없으므로 미확인 알림 수는 0으로 설정
+        int totalBookCount = shelfSummary.wantToReadCount()
+                + shelfSummary.finishedCount()
+                + shelfSummary.readingCount();
+
         return new HomeResponseDto.MeSummary(
                 member.getId(),
                 member.getNickname(),
                 member.getProfilePath(),
                 followerCount,
                 followingCount,
-                0
+                totalBookCount
         );
     }
 
@@ -154,6 +160,21 @@ public class HomeServiceImpl implements HomeService {
                         row.bookId(),
                         row.title(),
                         row.coverUrl()
+                ))
+                .toList();
+    }
+
+    private List<HomeResponseDto.BookRecommendation> buildRecommendations(Long memberId) {
+        List<Book> books = bookRepository.findRecommendedBooks(memberId, HOME_RECOMMENDATION_LIMIT);
+
+        return books.stream()
+                .map(book -> new HomeResponseDto.BookRecommendation(
+                        book.getId(),
+                        book.getTitle(),
+                        book.getAuthor(),
+                        book.getCoverImageUrl(),
+                        List.of(book.getPublisher()),
+                        "리뷰 인기"
                 ))
                 .toList();
     }

--- a/src/main/java/monochrome/libri/inquiry/dto/response/InquiryListItemResponseDto.java
+++ b/src/main/java/monochrome/libri/inquiry/dto/response/InquiryListItemResponseDto.java
@@ -9,6 +9,7 @@ public record InquiryListItemResponseDto(
         long memberId,
         String memberNickname,
         String title,
+        String contentPreview,
         InquiryStatus status,
         LocalDateTime answeredAt,
         LocalDateTime createdAt

--- a/src/main/java/monochrome/libri/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/monochrome/libri/inquiry/service/impl/InquiryServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 public class InquiryServiceImpl implements InquiryService {
+    private static final int INQUIRY_PREVIEW_LENGTH = 40;
 
     private final InquiryRepository inquiryRepository;
     private final MemberService memberService;
@@ -123,11 +124,24 @@ public class InquiryServiceImpl implements InquiryService {
                         inquiry.getMember().getId(),
                         inquiry.getMember().getNickname(),
                         inquiry.getTitle(),
+                        summarizeContent(inquiry.getContent()),
                         inquiry.getStatus(),
                         inquiry.getAnsweredAt(),
                         inquiry.getCreatedDate()
                 ))
                 .toList();
+    }
+
+    private String summarizeContent(String content) {
+        if (content == null) {
+            return "";
+        }
+
+        String normalized = content.trim().replaceAll("\\s+", " ");
+        if (normalized.length() <= INQUIRY_PREVIEW_LENGTH) {
+            return normalized;
+        }
+        return normalized.substring(0, INQUIRY_PREVIEW_LENGTH) + "...";
     }
 
     private Member getMemberOrThrow(long memberId) {

--- a/src/main/java/monochrome/libri/member/controller/MemberController.java
+++ b/src/main/java/monochrome/libri/member/controller/MemberController.java
@@ -5,13 +5,20 @@ import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.global.response.ApiResponse;
 import monochrome.libri.global.security.UserPrincipal;
 import monochrome.libri.global.swagger.ApiErrorCodes;
+import monochrome.libri.block.dto.response.BlockedMemberListResponseDto;
+import monochrome.libri.block.service.BlockService;
 import monochrome.libri.member.dto.request.MemberUpdateRequestDto;
 import monochrome.libri.member.dto.request.NicknameUpdateRequestDto;
 import monochrome.libri.member.dto.request.PrivacyUpdateRequestDto;
+import monochrome.libri.member.dto.request.ProfileImageUpdateRequestDto;
+import monochrome.libri.member.dto.response.MemberPrivacyResponseDto;
+import monochrome.libri.member.dto.response.MemberProfileResponseDto;
 import monochrome.libri.member.dto.response.MemberResponseDto;
 import monochrome.libri.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,9 +29,11 @@ import jakarta.validation.Valid;
 @SecurityRequirement(name = "BearerAuth")
 public class MemberController {
     private final MemberService memberService;
+    private final BlockService blockService;
 
-    public MemberController(MemberService memberService) {
+    public MemberController(MemberService memberService, BlockService blockService) {
         this.memberService = memberService;
+        this.blockService = blockService;
     }
 
     @GetMapping("/me")
@@ -43,9 +52,110 @@ public class MemberController {
             throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
         }
 
-        var member = memberService.getMemberById(userPrincipal.getMemberId())
-                .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
-        return ResponseEntity.ok(ApiResponse.ok(MemberResponseDto.from(member)));
+        return ResponseEntity.ok(ApiResponse.ok(memberService.getMyProfile(userPrincipal.getMemberId())));
+    }
+
+    @GetMapping("/me/privacy")
+    @Operation(
+            summary = "내 비공개 여부 조회",
+            description = "로그인한 회원의 계정 비공개 여부를 조회합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.MEMBER_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<MemberPrivacyResponseDto>> getMyPrivacy(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        return ResponseEntity.ok(ApiResponse.ok(memberService.getMyPrivacy(userPrincipal.getMemberId())));
+    }
+
+    @GetMapping("/me/blocks")
+    @Operation(
+            summary = "차단한 회원 목록 조회",
+            description = "로그인한 회원이 차단한 회원 목록을 조회합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.MEMBER_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<BlockedMemberListResponseDto>> getMyBlockedMembers(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        if (page < 0 || size <= 0) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(ApiResponse.ok(blockService.getBlockedMembers(userPrincipal.getMemberId(), pageable)));
+    }
+
+    @GetMapping("/{memberId}")
+    @Operation(
+            summary = "회원 프로필 조회",
+            description = "다른 회원의 프로필 정보를 조회합니다. 로그인 상태면 본인 여부와 팔로우 여부를 함께 반환합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<MemberProfileResponseDto>> getMemberProfile(
+            @PathVariable long memberId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        Long actorMemberId = userPrincipal == null ? null : userPrincipal.getMemberId();
+        return ResponseEntity.ok(ApiResponse.ok(memberService.getMemberProfile(actorMemberId, memberId)));
+    }
+
+    @PostMapping("/{memberId}/block")
+    @Operation(
+            summary = "회원 차단",
+            description = "특정 회원을 차단합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.SELF_BLOCK_NOT_ALLOWED,
+            ErrorCode.BLOCK_ALREADY_EXISTS
+    })
+    public ResponseEntity<ApiResponse<Void>> blockMember(
+            @PathVariable long memberId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        blockService.blockMember(userPrincipal.getMemberId(), memberId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    @DeleteMapping("/{memberId}/block")
+    @Operation(
+            summary = "회원 차단 해제",
+            description = "차단한 회원을 차단 해제합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.SELF_BLOCK_NOT_ALLOWED,
+            ErrorCode.BLOCK_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<Void>> unblockMember(
+            @PathVariable long memberId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        blockService.unblockMember(userPrincipal.getMemberId(), memberId);
+        return ResponseEntity.ok(ApiResponse.ok());
     }
 
     /**
@@ -102,7 +212,7 @@ public class MemberController {
                 null
         );
         var updated = memberService.updateMember(userPrincipal.getMemberId(), updateRequest);
-        return ResponseEntity.ok(ApiResponse.ok(MemberResponseDto.from(updated)));
+        return ResponseEntity.ok(ApiResponse.ok(memberService.getMyProfile(updated.getId())));
     }
 
     @PatchMapping("/me/privacy")
@@ -136,6 +246,40 @@ public class MemberController {
                 null
         );
         var updated = memberService.updateMember(userPrincipal.getMemberId(), updateRequest);
-        return ResponseEntity.ok(ApiResponse.ok(MemberResponseDto.from(updated)));
+        return ResponseEntity.ok(ApiResponse.ok(memberService.getMyProfile(updated.getId())));
+    }
+
+    @PatchMapping("/me/profile-image")
+    @Operation(
+            summary = "프로필 이미지 경로 저장",
+            description = "S3 업로드 후 프로필 이미지 경로를 회원 정보에 저장합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<MemberResponseDto>> updateProfileImage(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody ProfileImageUpdateRequestDto request
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        MemberUpdateRequestDto updateRequest = new MemberUpdateRequestDto(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                request.profilePath(),
+                null,
+                null,
+                null
+        );
+        var updated = memberService.updateMember(userPrincipal.getMemberId(), updateRequest);
+        return ResponseEntity.ok(ApiResponse.ok(memberService.getMyProfile(updated.getId())));
     }
 }

--- a/src/main/java/monochrome/libri/member/dto/request/ProfileImageUpdateRequestDto.java
+++ b/src/main/java/monochrome/libri/member/dto/request/ProfileImageUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package monochrome.libri.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProfileImageUpdateRequestDto(
+        @NotBlank(message = "프로필 이미지 경로는 필수입니다.")
+        String profilePath
+) {
+}

--- a/src/main/java/monochrome/libri/member/dto/response/MemberPrivacyResponseDto.java
+++ b/src/main/java/monochrome/libri/member/dto/response/MemberPrivacyResponseDto.java
@@ -1,0 +1,7 @@
+package monochrome.libri.member.dto.response;
+
+public record MemberPrivacyResponseDto(
+        long memberId,
+        boolean privateAccount
+) {
+}

--- a/src/main/java/monochrome/libri/member/dto/response/MemberProfileResponseDto.java
+++ b/src/main/java/monochrome/libri/member/dto/response/MemberProfileResponseDto.java
@@ -1,0 +1,35 @@
+package monochrome.libri.member.dto.response;
+
+import monochrome.libri.member.domain.Member;
+
+public record MemberProfileResponseDto(
+        long memberId,
+        String username,
+        String nickname,
+        String profilePath,
+        boolean privateAccount,
+        long followerCount,
+        long followingCount,
+        boolean mine,
+        boolean following
+) {
+    public static MemberProfileResponseDto from(
+            Member member,
+            long followerCount,
+            long followingCount,
+            boolean mine,
+            boolean following
+    ) {
+        return new MemberProfileResponseDto(
+                member.getId(),
+                member.getUsername(),
+                member.getNickname(),
+                member.getProfilePath(),
+                member.isPrivateAccount(),
+                followerCount,
+                followingCount,
+                mine,
+                following
+        );
+    }
+}

--- a/src/main/java/monochrome/libri/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/monochrome/libri/member/dto/response/MemberResponseDto.java
@@ -11,16 +11,24 @@ public record MemberResponseDto(
     String email,
     String nickname,
     String profilePath,
-    boolean privateAccount
+    boolean privateAccount,
+    long followerCount,
+    long followingCount
 ) {
     public static MemberResponseDto from(Member member) {
+        return from(member, 0L, 0L);
+    }
+
+    public static MemberResponseDto from(Member member, long followerCount, long followingCount) {
         return new MemberResponseDto(
                 member.getId(),
                 member.getProvider(),
                 member.getEmail(),
                 member.getNickname(),
                 member.getProfilePath(),
-                member.isPrivateAccount()
+                member.isPrivateAccount(),
+                followerCount,
+                followingCount
         );
     }
 }

--- a/src/main/java/monochrome/libri/member/service/MemberService.java
+++ b/src/main/java/monochrome/libri/member/service/MemberService.java
@@ -2,6 +2,9 @@ package monochrome.libri.member.service;
 
 import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.dto.request.MemberUpdateRequestDto;
+import monochrome.libri.member.dto.response.MemberPrivacyResponseDto;
+import monochrome.libri.member.dto.response.MemberProfileResponseDto;
+import monochrome.libri.member.dto.response.MemberResponseDto;
 
 import java.util.Optional;
 
@@ -13,6 +16,12 @@ public interface MemberService {
      * @return 수정된 Member 엔티티
      */
     Member updateMember(long memberId, MemberUpdateRequestDto memberUpdateRequestDto);
+
+    MemberResponseDto getMyProfile(long memberId);
+
+    MemberPrivacyResponseDto getMyPrivacy(long memberId);
+
+    MemberProfileResponseDto getMemberProfile(Long actorMemberId, long targetMemberId);
 
     /**
      * ID로 회원 조회

--- a/src/main/java/monochrome/libri/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/monochrome/libri/member/service/impl/MemberServiceImpl.java
@@ -1,10 +1,16 @@
 package monochrome.libri.member.service.impl;
 
+import monochrome.libri.block.service.BlockService;
+import monochrome.libri.follow.domain.FollowStatus;
+import monochrome.libri.follow.repository.FollowRepository;
 import monochrome.libri.global.exception.ErrorCode;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.global.security.PasswordHashService;
 import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.dto.request.MemberUpdateRequestDto;
+import monochrome.libri.member.dto.response.MemberPrivacyResponseDto;
+import monochrome.libri.member.dto.response.MemberProfileResponseDto;
+import monochrome.libri.member.dto.response.MemberResponseDto;
 import monochrome.libri.member.repository.MemberRepository;
 import monochrome.libri.member.service.MemberService;
 import org.springframework.stereotype.Service;
@@ -16,10 +22,19 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+    private final BlockService blockService;
     private final PasswordHashService passwordHashService;
 
-    public MemberServiceImpl(MemberRepository memberRepository, PasswordHashService passwordHashService) {
+    public MemberServiceImpl(
+            MemberRepository memberRepository,
+            FollowRepository followRepository,
+            BlockService blockService,
+            PasswordHashService passwordHashService
+    ) {
         this.memberRepository = memberRepository;
+        this.followRepository = followRepository;
+        this.blockService = blockService;
         this.passwordHashService = passwordHashService;
     }
 
@@ -58,10 +73,51 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public MemberResponseDto getMyProfile(long memberId) {
+        Member member = getRequiredMember(memberId);
+        return MemberResponseDto.from(
+                member,
+                followRepository.countByFollowingAndFollowStatus(member, FollowStatus.FOLLOW),
+                followRepository.countByFollowerAndFollowStatus(member, FollowStatus.FOLLOW)
+        );
+    }
+
+    @Override
+    public MemberPrivacyResponseDto getMyPrivacy(long memberId) {
+        Member member = getRequiredMember(memberId);
+        return new MemberPrivacyResponseDto(member.getId(), member.isPrivateAccount());
+    }
+
+    @Override
+    public MemberProfileResponseDto getMemberProfile(Long actorMemberId, long targetMemberId) {
+        Member target = getRequiredMember(targetMemberId);
+        if (actorMemberId != null && actorMemberId > 0 && blockService.hasBlockRelation(actorMemberId, targetMemberId)) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
+        long followerCount = followRepository.countByFollowingAndFollowStatus(target, FollowStatus.FOLLOW);
+        long followingCount = followRepository.countByFollowerAndFollowStatus(target, FollowStatus.FOLLOW);
+        boolean mine = actorMemberId != null && actorMemberId == targetMemberId;
+        boolean following = false;
+
+        if (!mine && actorMemberId != null && actorMemberId > 0) {
+            Member actor = getRequiredMember(actorMemberId);
+            following = followRepository.findByFollowerAndFollowing(actor, target)
+                    .map(relation -> relation.getFollowStatus() == FollowStatus.FOLLOW)
+                    .orElse(false);
+        }
+
+        return MemberProfileResponseDto.from(target, followerCount, followingCount, mine, following);
+    }
+
+    @Override
     public void withdraw(Long memberId) {
-        Member member = getMemberById(memberId)
-                .orElseThrow(()->new LibriException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = getRequiredMember(memberId);
 
         member.withdraw();
+    }
+
+    private Member getRequiredMember(long memberId) {
+        return getMemberById(memberId)
+                .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/monochrome/libri/note/service/impl/NoteServiceImpl.java
+++ b/src/main/java/monochrome/libri/note/service/impl/NoteServiceImpl.java
@@ -1,5 +1,6 @@
 package monochrome.libri.note.service.impl;
 
+import monochrome.libri.block.service.BlockService;
 import monochrome.libri.global.exception.ErrorCode;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.member.domain.Member;
@@ -39,6 +40,7 @@ public class NoteServiceImpl implements NoteService {
     private final NoteLikeRepository noteLikeRepository;
     private final NoteBookmarkRepository noteBookmarkRepository;
     private final NoteCommentRepository noteCommentRepository;
+    private final BlockService blockService;
 
     public NoteServiceImpl(
             NoteRepository noteRepository,
@@ -46,7 +48,8 @@ public class NoteServiceImpl implements NoteService {
             MemberService memberService,
             NoteLikeRepository noteLikeRepository,
             NoteBookmarkRepository noteBookmarkRepository,
-            NoteCommentRepository noteCommentRepository
+            NoteCommentRepository noteCommentRepository,
+            BlockService blockService
     ) {
         this.noteRepository = noteRepository;
         this.shelfRepository = shelfRepository;
@@ -54,6 +57,7 @@ public class NoteServiceImpl implements NoteService {
         this.noteLikeRepository = noteLikeRepository;
         this.noteBookmarkRepository = noteBookmarkRepository;
         this.noteCommentRepository = noteCommentRepository;
+        this.blockService = blockService;
     }
 
     @Override
@@ -205,6 +209,9 @@ public class NoteServiceImpl implements NoteService {
                 .orElseThrow(() -> new LibriException(ErrorCode.NOTE_NOT_FOUND));
 
         boolean isOwner = memberId > 0 && note.getMember().getId() == memberId;
+        if (!isOwner && blockService.hasBlockRelation(memberId, note.getMember().getId())) {
+            throw new LibriException(ErrorCode.ACCESS_DENIED);
+        }
         if (note.isSecret() && !isOwner) {
             throw new LibriException(ErrorCode.ACCESS_DENIED);
         }

--- a/src/main/java/monochrome/libri/shelf/controller/ShelfController.java
+++ b/src/main/java/monochrome/libri/shelf/controller/ShelfController.java
@@ -14,6 +14,8 @@ import monochrome.libri.note.service.NoteService;
 import monochrome.libri.shelf.domain.ShelfStatus;
 import monochrome.libri.shelf.dto.request.ShelfCreateRequestDto;
 import monochrome.libri.shelf.dto.request.ShelfUpdateRequestDto;
+import monochrome.libri.shelf.dto.response.ReadingCalendarResponseDto;
+import monochrome.libri.shelf.dto.response.ReadingStatisticsResponseDto;
 import monochrome.libri.shelf.dto.response.ShelfDetailResponseDto;
 import monochrome.libri.shelf.dto.response.ShelfListResponseDto;
 import monochrome.libri.shelf.service.ShelfService;
@@ -34,6 +36,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.DeleteMapping;
+
+import java.time.YearMonth;
 
 @RestController
 @RequestMapping("/api/v1/shelves")
@@ -70,6 +74,60 @@ public class ShelfController {
         Pageable pageable = PageRequest.of(page, size);
         Long memberId = userPrincipal == null ? null : userPrincipal.getMemberId();
         ShelfListResponseDto response = shelfService.getShelvesByStatus(memberId, status, pageable);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/calendar")
+    @Operation(
+            summary = "독서 달력 조회",
+            description = "선택한 월의 독서 시작/완독 기록을 날짜별 책 표지와 함께 조회합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<ReadingCalendarResponseDto>> getReadingCalendar(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        YearMonth current = YearMonth.now();
+        int resolvedYear = year == null ? current.getYear() : year;
+        int resolvedMonth = month == null ? current.getMonthValue() : month;
+        if (resolvedMonth < 1 || resolvedMonth > 12) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        ReadingCalendarResponseDto response = shelfService.getReadingCalendar(
+                userPrincipal.getMemberId(),
+                YearMonth.of(resolvedYear, resolvedMonth)
+        );
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/statistics")
+    @Operation(
+            summary = "독서 통계 조회",
+            description = "선택한 연도의 총 시작/완독 권수와 월별 완독 수, 누적 완독 수를 조회합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<ReadingStatisticsResponseDto>> getReadingStatistics(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(required = false) Integer year
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        int resolvedYear = year == null ? YearMonth.now().getYear() : year;
+        ReadingStatisticsResponseDto response = shelfService.getReadingStatistics(userPrincipal.getMemberId(), resolvedYear);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/src/main/java/monochrome/libri/shelf/dto/MonthCountRow.java
+++ b/src/main/java/monochrome/libri/shelf/dto/MonthCountRow.java
@@ -1,0 +1,7 @@
+package monochrome.libri.shelf.dto;
+
+public record MonthCountRow(
+        Integer month,
+        Long count
+) {
+}

--- a/src/main/java/monochrome/libri/shelf/dto/ShelfCalendarRow.java
+++ b/src/main/java/monochrome/libri/shelf/dto/ShelfCalendarRow.java
@@ -1,0 +1,16 @@
+package monochrome.libri.shelf.dto;
+
+import monochrome.libri.shelf.domain.ShelfStatus;
+
+import java.time.LocalDate;
+
+public record ShelfCalendarRow(
+        Long shelfId,
+        Long bookId,
+        String title,
+        String coverUrl,
+        LocalDate startDate,
+        LocalDate endDate,
+        ShelfStatus status
+) {
+}

--- a/src/main/java/monochrome/libri/shelf/dto/YearCountRow.java
+++ b/src/main/java/monochrome/libri/shelf/dto/YearCountRow.java
@@ -1,0 +1,7 @@
+package monochrome.libri.shelf.dto;
+
+public record YearCountRow(
+        Integer year,
+        Long count
+) {
+}

--- a/src/main/java/monochrome/libri/shelf/dto/response/ReadingCalendarResponseDto.java
+++ b/src/main/java/monochrome/libri/shelf/dto/response/ReadingCalendarResponseDto.java
@@ -1,0 +1,25 @@
+package monochrome.libri.shelf.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ReadingCalendarResponseDto(
+        int year,
+        int month,
+        List<CalendarDay> days
+) {
+    public record CalendarDay(
+            LocalDate date,
+            List<BookEvent> startedBooks,
+            List<BookEvent> finishedBooks
+    ) {
+    }
+
+    public record BookEvent(
+            Long shelfId,
+            Long bookId,
+            String title,
+            String coverUrl
+    ) {
+    }
+}

--- a/src/main/java/monochrome/libri/shelf/dto/response/ReadingStatisticsResponseDto.java
+++ b/src/main/java/monochrome/libri/shelf/dto/response/ReadingStatisticsResponseDto.java
@@ -1,0 +1,24 @@
+package monochrome.libri.shelf.dto.response;
+
+import java.util.List;
+
+public record ReadingStatisticsResponseDto(
+        int selectedYear,
+        long totalStartedCount,
+        long totalFinishedCount,
+        List<YearlyCount> yearlyFinishedCounts,
+        List<MonthlyCount> monthlyFinishedCounts,
+        List<MonthlyCount> monthlyCumulativeFinishedCounts
+) {
+    public record YearlyCount(
+            int year,
+            long count
+    ) {
+    }
+
+    public record MonthlyCount(
+            int month,
+            long count
+    ) {
+    }
+}

--- a/src/main/java/monochrome/libri/shelf/repository/ShelfRepository.java
+++ b/src/main/java/monochrome/libri/shelf/repository/ShelfRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Repository
@@ -19,4 +20,6 @@ public interface ShelfRepository extends JpaRepository<Shelf, Long>, ShelfReposi
     Slice<Shelf> findByMemberIdAndStatusOrderByCreatedDateDesc(long memberId, ShelfStatus status, Pageable pageable);
 
     long countByMemberIdAndStatus(long memberId, ShelfStatus status);
+    long countByMemberIdAndStartDateBetween(long memberId, LocalDate startDate, LocalDate endDate);
+    long countByMemberIdAndStatusAndEndDateBetween(long memberId, ShelfStatus status, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/monochrome/libri/shelf/repository/ShelfRepositoryCustom.java
+++ b/src/main/java/monochrome/libri/shelf/repository/ShelfRepositoryCustom.java
@@ -1,12 +1,22 @@
 package monochrome.libri.shelf.repository;
 
 import monochrome.libri.shelf.domain.ShelfStatus;
+import monochrome.libri.shelf.dto.MonthCountRow;
+import monochrome.libri.shelf.dto.ShelfCalendarRow;
 import monochrome.libri.shelf.dto.ShelfBookRow;
+import monochrome.libri.shelf.dto.YearCountRow;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ShelfRepositoryCustom {
     ShelfCountSummary findCountSummaryByMemberId(long memberId);
 
     List<ShelfBookRow> findShelfBooksByStatus(long memberId, ShelfStatus status, int limit);
+
+    List<ShelfCalendarRow> findCalendarRowsByMemberIdAndDateRange(long memberId, LocalDate from, LocalDate to);
+
+    List<YearCountRow> countFinishedBooksByYear(long memberId);
+
+    List<MonthCountRow> countFinishedBooksByMonth(long memberId, int year);
 }

--- a/src/main/java/monochrome/libri/shelf/repository/ShelfRepositoryCustomImpl.java
+++ b/src/main/java/monochrome/libri/shelf/repository/ShelfRepositoryCustomImpl.java
@@ -1,14 +1,22 @@
 package monochrome.libri.shelf.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import monochrome.libri.book.domain.QBook;
 import monochrome.libri.shelf.domain.QShelf;
 import monochrome.libri.shelf.domain.ShelfStatus;
+import monochrome.libri.shelf.dto.MonthCountRow;
+import monochrome.libri.shelf.dto.ShelfCalendarRow;
 import monochrome.libri.shelf.dto.ShelfBookRow;
+import monochrome.libri.shelf.dto.YearCountRow;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public class ShelfRepositoryCustomImpl implements ShelfRepositoryCustom {
 
@@ -84,6 +92,78 @@ public class ShelfRepositoryCustomImpl implements ShelfRepositoryCustom {
                 )
                 .orderBy(s.id.desc())
                 .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<ShelfCalendarRow> findCalendarRowsByMemberIdAndDateRange(long memberId, LocalDate from, LocalDate to) {
+        QShelf s = QShelf.shelf;
+        QBook b = QBook.book;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        ShelfCalendarRow.class,
+                        s.id,
+                        b.id,
+                        b.title,
+                        b.coverImageUrl,
+                        s.startDate,
+                        s.endDate,
+                        s.status
+                ))
+                .from(s)
+                .join(s.book, b)
+                .where(
+                        s.member.id.eq(memberId),
+                        s.startDate.between(from, to)
+                                .or(s.status.eq(ShelfStatus.FINISHED).and(s.endDate.between(from, to)))
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<YearCountRow> countFinishedBooksByYear(long memberId) {
+        QShelf s = QShelf.shelf;
+        NumberTemplate<Integer> yearExpr = Expressions.numberTemplate(Integer.class, "year({0})", s.endDate);
+
+        return queryFactory
+                .select(Projections.constructor(
+                        YearCountRow.class,
+                        yearExpr,
+                        s.id.count()
+                ))
+                .from(s)
+                .where(
+                        s.member.id.eq(memberId),
+                        s.status.eq(ShelfStatus.FINISHED),
+                        s.endDate.isNotNull()
+                )
+                .groupBy(yearExpr)
+                .orderBy(yearExpr.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<MonthCountRow> countFinishedBooksByMonth(long memberId, int year) {
+        QShelf s = QShelf.shelf;
+        NumberTemplate<Integer> yearExpr = Expressions.numberTemplate(Integer.class, "year({0})", s.endDate);
+        NumberTemplate<Integer> monthExpr = Expressions.numberTemplate(Integer.class, "month({0})", s.endDate);
+
+        return queryFactory
+                .select(Projections.constructor(
+                        MonthCountRow.class,
+                        monthExpr,
+                        s.id.count()
+                ))
+                .from(s)
+                .where(
+                        s.member.id.eq(memberId),
+                        s.status.eq(ShelfStatus.FINISHED),
+                        s.endDate.isNotNull(),
+                        yearExpr.eq(year)
+                )
+                .groupBy(monthExpr)
+                .orderBy(monthExpr.asc())
                 .fetch();
     }
 }

--- a/src/main/java/monochrome/libri/shelf/service/ShelfService.java
+++ b/src/main/java/monochrome/libri/shelf/service/ShelfService.java
@@ -1,5 +1,7 @@
 package monochrome.libri.shelf.service;
 
+import monochrome.libri.shelf.dto.response.ReadingCalendarResponseDto;
+import monochrome.libri.shelf.dto.response.ReadingStatisticsResponseDto;
 import monochrome.libri.shelf.dto.response.ShelfDetailResponseDto;
 import monochrome.libri.shelf.dto.response.ShelfListResponseDto;
 import monochrome.libri.shelf.dto.request.ShelfUpdateRequestDto;
@@ -7,9 +9,13 @@ import monochrome.libri.shelf.dto.request.ShelfCreateRequestDto;
 import monochrome.libri.shelf.domain.ShelfStatus;
 import org.springframework.data.domain.Pageable;
 
+import java.time.YearMonth;
+
 public interface ShelfService {
     ShelfDetailResponseDto getShelfDetail(long shelfId, Long memberId);
     ShelfListResponseDto getShelvesByStatus(Long memberId, ShelfStatus status, Pageable pageable);
+    ReadingCalendarResponseDto getReadingCalendar(long memberId, YearMonth yearMonth);
+    ReadingStatisticsResponseDto getReadingStatistics(long memberId, int year);
     ShelfDetailResponseDto updateShelf(long shelfId, Long memberId, ShelfUpdateRequestDto request);
     void createShelf(long memberId, ShelfCreateRequestDto request);
 }

--- a/src/main/java/monochrome/libri/shelf/service/impl/ShelfServiceImpl.java
+++ b/src/main/java/monochrome/libri/shelf/service/impl/ShelfServiceImpl.java
@@ -8,6 +8,9 @@ import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.service.MemberService;
 import monochrome.libri.review.service.ReviewService;
 import monochrome.libri.shelf.domain.Shelf;
+import monochrome.libri.shelf.domain.ShelfStatus;
+import monochrome.libri.shelf.dto.response.ReadingCalendarResponseDto;
+import monochrome.libri.shelf.dto.response.ReadingStatisticsResponseDto;
 import monochrome.libri.shelf.dto.response.ShelfDetailResponseDto;
 import monochrome.libri.shelf.dto.response.ShelfListItemResponseDto;
 import monochrome.libri.shelf.dto.response.ShelfListResponseDto;
@@ -22,8 +25,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 @Service
@@ -81,6 +88,100 @@ public class ShelfServiceImpl implements ShelfService {
                 slice.hasNext(),
                 slice.getNumber(),
                 slice.getSize()
+        );
+    }
+
+    @Override
+    public ReadingCalendarResponseDto getReadingCalendar(long memberId, YearMonth yearMonth) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        LocalDate from = yearMonth.atDay(1);
+        LocalDate to = yearMonth.atEndOfMonth();
+        var rows = shelfRepository.findCalendarRowsByMemberIdAndDateRange(memberId, from, to);
+        Map<LocalDate, List<ReadingCalendarResponseDto.BookEvent>> startedByDate = new HashMap<>();
+        Map<LocalDate, List<ReadingCalendarResponseDto.BookEvent>> finishedByDate = new HashMap<>();
+
+        for (var row : rows) {
+            ReadingCalendarResponseDto.BookEvent event = new ReadingCalendarResponseDto.BookEvent(
+                    row.shelfId(),
+                    row.bookId(),
+                    row.title(),
+                    row.coverUrl()
+            );
+            if (row.startDate() != null && !row.startDate().isBefore(from) && !row.startDate().isAfter(to)) {
+                startedByDate.computeIfAbsent(row.startDate(), ignored -> new ArrayList<>()).add(event);
+            }
+            if (row.status() == ShelfStatus.FINISHED
+                    && row.endDate() != null
+                    && !row.endDate().isBefore(from)
+                    && !row.endDate().isAfter(to)) {
+                finishedByDate.computeIfAbsent(row.endDate(), ignored -> new ArrayList<>()).add(event);
+            }
+        }
+
+        List<ReadingCalendarResponseDto.CalendarDay> days = new ArrayList<>();
+        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+            days.add(new ReadingCalendarResponseDto.CalendarDay(
+                    date,
+                    startedByDate.getOrDefault(date, List.of()),
+                    finishedByDate.getOrDefault(date, List.of())
+            ));
+        }
+
+        return new ReadingCalendarResponseDto(yearMonth.getYear(), yearMonth.getMonthValue(), days);
+    }
+
+    @Override
+    public ReadingStatisticsResponseDto getReadingStatistics(long memberId, int year) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        LocalDate from = LocalDate.of(year, 1, 1);
+        LocalDate to = LocalDate.of(year, 12, 31);
+
+        long totalStartedCount = shelfRepository.countByMemberIdAndStartDateBetween(memberId, from, to);
+        long totalFinishedCount = shelfRepository.countByMemberIdAndStatusAndEndDateBetween(
+                memberId,
+                ShelfStatus.FINISHED,
+                from,
+                to
+        );
+
+        List<ReadingStatisticsResponseDto.YearlyCount> yearlyFinishedCounts = shelfRepository.countFinishedBooksByYear(memberId)
+                .stream()
+                .map(row -> new ReadingStatisticsResponseDto.YearlyCount(
+                        row.year() == null ? year : row.year(),
+                        row.count() == null ? 0L : row.count()
+                ))
+                .toList();
+
+        Map<Integer, Long> monthlyFinishedMap = new HashMap<>();
+        for (var row : shelfRepository.countFinishedBooksByMonth(memberId, year)) {
+            if (row.month() != null) {
+                monthlyFinishedMap.put(row.month(), row.count() == null ? 0L : row.count());
+            }
+        }
+
+        List<ReadingStatisticsResponseDto.MonthlyCount> monthlyFinishedCounts = new ArrayList<>();
+        List<ReadingStatisticsResponseDto.MonthlyCount> monthlyCumulativeFinishedCounts = new ArrayList<>();
+        long cumulative = 0L;
+        for (int month = 1; month <= 12; month++) {
+            long count = monthlyFinishedMap.getOrDefault(month, 0L);
+            cumulative += count;
+            monthlyFinishedCounts.add(new ReadingStatisticsResponseDto.MonthlyCount(month, count));
+            monthlyCumulativeFinishedCounts.add(new ReadingStatisticsResponseDto.MonthlyCount(month, cumulative));
+        }
+
+        return new ReadingStatisticsResponseDto(
+                year,
+                totalStartedCount,
+                totalFinishedCount,
+                yearlyFinishedCounts,
+                monthlyFinishedCounts,
+                monthlyCumulativeFinishedCounts
         );
     }
 

--- a/src/main/java/monochrome/libri/storage/config/S3Config.java
+++ b/src/main/java/monochrome/libri/storage/config/S3Config.java
@@ -1,0 +1,36 @@
+package monochrome.libri.storage.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@EnableConfigurationProperties(S3Properties.class)
+public class S3Config {
+
+    @Bean
+    public S3Presigner s3Presigner(S3Properties properties) {
+        String accessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
+        String secretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+        Region region = Region.of(properties.region());
+
+        S3Presigner.Builder builder = S3Presigner.builder()
+                .region(region);
+
+        if (accessKeyId != null && !accessKeyId.isBlank()
+                && secretAccessKey != null && !secretAccessKey.isBlank()) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+            ));
+        } else {
+            builder.credentialsProvider(DefaultCredentialsProvider.create());
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/monochrome/libri/storage/config/S3Properties.java
+++ b/src/main/java/monochrome/libri/storage/config/S3Properties.java
@@ -1,0 +1,12 @@
+package monochrome.libri.storage.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.s3")
+public record S3Properties(
+        String region,
+        String bucket,
+        String publicBaseUrl,
+        long uploadExpirationSeconds
+) {
+}

--- a/src/main/java/monochrome/libri/storage/controller/FileController.java
+++ b/src/main/java/monochrome/libri/storage/controller/FileController.java
@@ -1,0 +1,52 @@
+package monochrome.libri.storage.controller;
+
+import jakarta.validation.Valid;
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.global.response.ApiResponse;
+import monochrome.libri.global.security.UserPrincipal;
+import monochrome.libri.global.swagger.ApiErrorCodes;
+import monochrome.libri.storage.dto.request.PresignedUploadRequestDto;
+import monochrome.libri.storage.dto.response.PresignedUploadResponseDto;
+import monochrome.libri.storage.service.PresignedUploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@SecurityRequirement(name = "BearerAuth")
+public class FileController {
+
+    private final PresignedUploadService presignedUploadService;
+
+    public FileController(PresignedUploadService presignedUploadService) {
+        this.presignedUploadService = presignedUploadService;
+    }
+
+    @PostMapping("/presigned-upload")
+    @Operation(
+            summary = "S3 업로드용 presigned URL 발급",
+            description = "클라이언트가 S3에 직접 업로드할 수 있는 presigned URL을 발급합니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<PresignedUploadResponseDto>> createPresignedUploadUrl(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody PresignedUploadRequestDto request
+    ) {
+        if (userPrincipal == null) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        return ResponseEntity.ok(ApiResponse.ok(
+                presignedUploadService.createPresignedUploadUrl(userPrincipal.getMemberId(), request)
+        ));
+    }
+}

--- a/src/main/java/monochrome/libri/storage/dto/request/PresignedUploadRequestDto.java
+++ b/src/main/java/monochrome/libri/storage/dto/request/PresignedUploadRequestDto.java
@@ -1,0 +1,13 @@
+package monochrome.libri.storage.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUploadRequestDto(
+        @NotBlank(message = "디렉토리는 필수입니다.")
+        String directory,
+        @NotBlank(message = "파일명은 필수입니다.")
+        String fileName,
+        @NotBlank(message = "콘텐츠 타입은 필수입니다.")
+        String contentType
+) {
+}

--- a/src/main/java/monochrome/libri/storage/dto/response/PresignedUploadResponseDto.java
+++ b/src/main/java/monochrome/libri/storage/dto/response/PresignedUploadResponseDto.java
@@ -1,0 +1,9 @@
+package monochrome.libri.storage.dto.response;
+
+public record PresignedUploadResponseDto(
+        String uploadUrl,
+        String key,
+        String fileUrl,
+        long expiresInSeconds
+) {
+}

--- a/src/main/java/monochrome/libri/storage/service/PresignedUploadService.java
+++ b/src/main/java/monochrome/libri/storage/service/PresignedUploadService.java
@@ -1,0 +1,8 @@
+package monochrome.libri.storage.service;
+
+import monochrome.libri.storage.dto.request.PresignedUploadRequestDto;
+import monochrome.libri.storage.dto.response.PresignedUploadResponseDto;
+
+public interface PresignedUploadService {
+    PresignedUploadResponseDto createPresignedUploadUrl(long memberId, PresignedUploadRequestDto request);
+}

--- a/src/main/java/monochrome/libri/storage/service/impl/PresignedUploadServiceImpl.java
+++ b/src/main/java/monochrome/libri/storage/service/impl/PresignedUploadServiceImpl.java
@@ -1,0 +1,104 @@
+package monochrome.libri.storage.service.impl;
+
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.storage.config.S3Properties;
+import monochrome.libri.storage.dto.request.PresignedUploadRequestDto;
+import monochrome.libri.storage.dto.response.PresignedUploadResponseDto;
+import monochrome.libri.storage.service.PresignedUploadService;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class PresignedUploadServiceImpl implements PresignedUploadService {
+
+    private static final Set<String> SUPPORTED_DIRECTORIES = Set.of("profiles");
+    private static final Set<String> SUPPORTED_CONTENT_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+    );
+
+    private final S3Presigner s3Presigner;
+    private final S3Properties s3Properties;
+
+    public PresignedUploadServiceImpl(S3Presigner s3Presigner, S3Properties s3Properties) {
+        this.s3Presigner = s3Presigner;
+        this.s3Properties = s3Properties;
+    }
+
+    @Override
+    public PresignedUploadResponseDto createPresignedUploadUrl(long memberId, PresignedUploadRequestDto request) {
+        if (memberId <= 0) {
+            throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        if (request == null || request.directory() == null || request.fileName() == null || request.contentType() == null) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (s3Properties.bucket() == null || s3Properties.bucket().isBlank()) {
+            throw new LibriException(ErrorCode.S3_CONFIGURATION_MISSING);
+        }
+
+        String directory = request.directory().trim();
+        String fileName = request.fileName().trim();
+        String contentType = request.contentType().trim();
+
+        if (!SUPPORTED_DIRECTORIES.contains(directory) || !SUPPORTED_CONTENT_TYPES.contains(contentType)) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        String key = buildObjectKey(directory, memberId, fileName);
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(s3Properties.bucket())
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(s3Properties.uploadExpirationSeconds()))
+                .putObjectRequest(putObjectRequest)
+                .build();
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+
+        return new PresignedUploadResponseDto(
+                presignedRequest.url().toString(),
+                key,
+                buildFileUrl(key),
+                s3Properties.uploadExpirationSeconds()
+        );
+    }
+
+    private String buildObjectKey(String directory, long memberId, String fileName) {
+        String extension = extractExtension(fileName);
+        return directory + "/" + memberId + "/" + UUID.randomUUID() + extension;
+    }
+
+    private String extractExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == fileName.length() - 1) {
+            return "";
+        }
+        return fileName.substring(dotIndex).toLowerCase();
+    }
+
+    private String buildFileUrl(String key) {
+        String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8).replace("+", "%20");
+        if (s3Properties.publicBaseUrl() != null && !s3Properties.publicBaseUrl().isBlank()) {
+            return trimTrailingSlash(s3Properties.publicBaseUrl()) + "/" + encodedKey;
+        }
+        return "https://" + s3Properties.bucket() + ".s3." + s3Properties.region() + ".amazonaws.com/" + encodedKey;
+    }
+
+    private String trimTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,10 @@ jwt:
   access-exp-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS}
   refresh-exp-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:1209600}
   issuer: ${JWT_ISSUER}
+
+app:
+  s3:
+    region: ${AWS_REGION:ap-northeast-2}
+    bucket: ${AWS_S3_BUCKET:}
+    public-base-url: ${AWS_S3_PUBLIC_BASE_URL:}
+    upload-expiration-seconds: ${AWS_S3_UPLOAD_EXPIRATION_SECONDS:300}

--- a/src/test/java/monochrome/libri/block/service/BlockServiceImplTest.java
+++ b/src/test/java/monochrome/libri/block/service/BlockServiceImplTest.java
@@ -1,0 +1,86 @@
+package monochrome.libri.block.service;
+
+import monochrome.libri.TestFixtures;
+import monochrome.libri.block.domain.MemberBlock;
+import monochrome.libri.block.repository.MemberBlockRepository;
+import monochrome.libri.block.service.impl.BlockServiceImpl;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.member.domain.Member;
+import monochrome.libri.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class BlockServiceImplTest {
+
+    @Test
+    void blockMember_savesNewBlock() {
+        MemberBlockRepository blockRepository = mock(MemberBlockRepository.class);
+        MemberRepository memberRepository = mock(MemberRepository.class);
+        BlockServiceImpl service = new BlockServiceImpl(blockRepository, memberRepository);
+        Member blocker = TestFixtures.member(1L);
+        Member blocked = TestFixtures.member(2L);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(memberRepository.findById(2L)).thenReturn(Optional.of(blocked));
+        when(blockRepository.existsByBlockerAndBlocked(blocker, blocked)).thenReturn(false);
+
+        service.blockMember(1L, 2L);
+
+        ArgumentCaptor<MemberBlock> captor = ArgumentCaptor.forClass(MemberBlock.class);
+        verify(blockRepository).save(captor.capture());
+        assertThat(captor.getValue().getBlocker()).isEqualTo(blocker);
+        assertThat(captor.getValue().getBlocked()).isEqualTo(blocked);
+    }
+
+    @Test
+    void blockMember_rejectsDuplicate() {
+        MemberBlockRepository blockRepository = mock(MemberBlockRepository.class);
+        MemberRepository memberRepository = mock(MemberRepository.class);
+        BlockServiceImpl service = new BlockServiceImpl(blockRepository, memberRepository);
+        Member blocker = TestFixtures.member(1L);
+        Member blocked = TestFixtures.member(2L);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(memberRepository.findById(2L)).thenReturn(Optional.of(blocked));
+        when(blockRepository.existsByBlockerAndBlocked(blocker, blocked)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.blockMember(1L, 2L))
+                .isInstanceOf(LibriException.class);
+        verify(blockRepository, never()).save(any());
+    }
+
+    @Test
+    void getBlockedMembers_returnsSlice() {
+        MemberBlockRepository blockRepository = mock(MemberBlockRepository.class);
+        MemberRepository memberRepository = mock(MemberRepository.class);
+        BlockServiceImpl service = new BlockServiceImpl(blockRepository, memberRepository);
+        Member blocker = TestFixtures.member(1L);
+        Member blocked = TestFixtures.member(2L);
+        MemberBlock memberBlock = MemberBlock.builder()
+                .id(10L)
+                .blocker(blocker)
+                .blocked(blocked)
+                .build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(blockRepository.findByBlockerIdOrderByCreatedDateDesc(1L, PageRequest.of(0, 20)))
+                .thenReturn(new SliceImpl<>(List.of(memberBlock), PageRequest.of(0, 20), false));
+        when(blockRepository.countByBlockerId(1L)).thenReturn(1L);
+
+        var response = service.getBlockedMembers(1L, PageRequest.of(0, 20));
+
+        assertThat(response.totalCount()).isEqualTo(1L);
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).memberId()).isEqualTo(2L);
+    }
+}

--- a/src/test/java/monochrome/libri/book/service/BookServiceImplTest.java
+++ b/src/test/java/monochrome/libri/book/service/BookServiceImplTest.java
@@ -92,6 +92,7 @@ class BookServiceImplTest {
         var response = service.getBookDetail(1L, 1L);
 
         assertThat(response.shelf()).isNotNull();
+        assertThat(response.totalPage()).isEqualTo(100);
         assertThat(response.reviews()).hasSize(1);
     }
 

--- a/src/test/java/monochrome/libri/comment/service/NoteCommentServiceImplTest.java
+++ b/src/test/java/monochrome/libri/comment/service/NoteCommentServiceImplTest.java
@@ -1,8 +1,13 @@
 package monochrome.libri.comment.service;
 
 import monochrome.libri.TestFixtures;
+import monochrome.libri.block.service.BlockService;
+import monochrome.libri.comment.domain.CommentReportReason;
 import monochrome.libri.comment.domain.NoteComment;
+import monochrome.libri.comment.domain.NoteCommentReport;
 import monochrome.libri.comment.dto.request.CommentCreateRequestDto;
+import monochrome.libri.comment.dto.request.CommentReportCreateRequestDto;
+import monochrome.libri.comment.repository.NoteCommentReportRepository;
 import monochrome.libri.comment.repository.NoteCommentRepository;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.member.domain.Member;
@@ -33,10 +38,16 @@ class NoteCommentServiceImplTest {
     private NoteCommentRepository commentRepository;
 
     @Mock
+    private NoteCommentReportRepository commentReportRepository;
+
+    @Mock
     private NoteRepository noteRepository;
 
     @Mock
     private MemberService memberService;
+
+    @Mock
+    private BlockService blockService;
 
     @InjectMocks
     private monochrome.libri.comment.service.impl.NoteCommentServiceImpl service;
@@ -61,6 +72,7 @@ class NoteCommentServiceImplTest {
         Note note = TestFixtures.note(2L, TestFixtures.shelf(3L, member, TestFixtures.book(4L, 100)), member, false);
 
         when(noteRepository.findWithMemberById(2L)).thenReturn(Optional.of(note));
+        when(blockService.hasBlockRelation(1L, 1L)).thenReturn(false);
         when(memberService.getMemberById(1L)).thenReturn(Optional.of(member));
 
         service.createComment(2L, 1L, new CommentCreateRequestDto("  hello "));
@@ -71,10 +83,63 @@ class NoteCommentServiceImplTest {
     }
 
     @Test
+    void reportComment_savesReport() {
+        Member reporter = TestFixtures.member(1L);
+        Member owner = TestFixtures.member(2L);
+        Note note = TestFixtures.note(3L, TestFixtures.shelf(4L, owner, TestFixtures.book(5L, 100)), owner, false);
+        NoteComment comment = NoteComment.builder()
+                .id(10L)
+                .note(note)
+                .member(owner)
+                .content("hey")
+                .build();
+
+        when(commentRepository.findWithNoteAndMemberByIdAndNoteId(10L, 3L)).thenReturn(Optional.of(comment));
+        when(blockService.hasBlockRelation(1L, 2L)).thenReturn(false);
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(reporter));
+        when(commentReportRepository.existsByNoteCommentAndReporter(comment, reporter)).thenReturn(false);
+
+        service.reportComment(3L, 10L, 1L, new CommentReportCreateRequestDto(CommentReportReason.SPAM, "  repeated ads  "));
+
+        ArgumentCaptor<NoteCommentReport> captor = ArgumentCaptor.forClass(NoteCommentReport.class);
+        verify(commentReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getReason()).isEqualTo(CommentReportReason.SPAM);
+        assertThat(captor.getValue().getDetail()).isEqualTo("repeated ads");
+    }
+
+    @Test
+    void reportComment_rejectsDuplicateReport() {
+        Member reporter = TestFixtures.member(1L);
+        Member owner = TestFixtures.member(2L);
+        Note note = TestFixtures.note(3L, TestFixtures.shelf(4L, owner, TestFixtures.book(5L, 100)), owner, false);
+        NoteComment comment = NoteComment.builder()
+                .id(10L)
+                .note(note)
+                .member(owner)
+                .content("hey")
+                .build();
+
+        when(commentRepository.findWithNoteAndMemberByIdAndNoteId(10L, 3L)).thenReturn(Optional.of(comment));
+        when(blockService.hasBlockRelation(1L, 2L)).thenReturn(false);
+        when(memberService.getMemberById(1L)).thenReturn(Optional.of(reporter));
+        when(commentReportRepository.existsByNoteCommentAndReporter(comment, reporter)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.reportComment(
+                3L,
+                10L,
+                1L,
+                new CommentReportCreateRequestDto(CommentReportReason.ABUSE, null)
+        )).isInstanceOf(LibriException.class);
+
+        verify(commentReportRepository, never()).save(any());
+    }
+
+    @Test
     void getComments_deniesSecretNoteForNonOwner() {
         Member owner = TestFixtures.member(1L);
         Note note = TestFixtures.note(2L, TestFixtures.shelf(3L, owner, TestFixtures.book(4L, 100)), owner, true);
         when(noteRepository.findWithMemberById(2L)).thenReturn(Optional.of(note));
+        when(blockService.hasBlockRelation(999L, 1L)).thenReturn(false);
 
         assertThatThrownBy(() -> service.getComments(2L, 999L, PageRequest.of(0, 10)))
                 .isInstanceOf(LibriException.class);

--- a/src/test/java/monochrome/libri/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/monochrome/libri/follow/service/FollowServiceImplTest.java
@@ -1,6 +1,7 @@
 package monochrome.libri.follow.service;
 
 import monochrome.libri.TestFixtures;
+import monochrome.libri.block.service.BlockService;
 import monochrome.libri.follow.domain.Follow;
 import monochrome.libri.follow.domain.FollowStatus;
 import monochrome.libri.follow.dto.MemberSummaryDto;
@@ -32,6 +33,9 @@ class FollowServiceImplTest {
     @Mock
     private MemberService memberService;
 
+    @Mock
+    private BlockService blockService;
+
     @InjectMocks
     private FollowServiceImpl service;
 
@@ -49,6 +53,7 @@ class FollowServiceImplTest {
 
         when(memberService.getMemberById(1L)).thenReturn(Optional.of(follower));
         when(memberService.getMemberById(2L)).thenReturn(Optional.of(following));
+        when(blockService.hasBlockRelation(1L, 2L)).thenReturn(false);
         when(followRepository.findByFollowerAndFollowing(follower, following)).thenReturn(Optional.of(relation));
 
         service.follow(1L, 2L);
@@ -65,10 +70,20 @@ class FollowServiceImplTest {
 
         when(memberService.getMemberById(1L)).thenReturn(Optional.of(follower));
         when(memberService.getMemberById(2L)).thenReturn(Optional.of(following));
+        when(blockService.hasBlockRelation(1L, 2L)).thenReturn(false);
         when(followRepository.findByFollowerAndFollowing(follower, following)).thenReturn(Optional.of(relation));
 
         assertThatThrownBy(() -> service.follow(1L, 2L))
                 .isInstanceOf(LibriException.class);
+    }
+
+    @Test
+    void follow_throwsWhenBlocked() {
+        when(blockService.hasBlockRelation(1L, 2L)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.follow(1L, 2L))
+                .isInstanceOf(LibriException.class);
+        verifyNoInteractions(memberService, followRepository);
     }
 
     @Test

--- a/src/test/java/monochrome/libri/home/service/HomeServiceImplTest.java
+++ b/src/test/java/monochrome/libri/home/service/HomeServiceImplTest.java
@@ -1,6 +1,8 @@
 package monochrome.libri.home.service;
 
 import monochrome.libri.TestFixtures;
+import monochrome.libri.book.domain.Book;
+import monochrome.libri.book.repository.BookRepository;
 import monochrome.libri.follow.domain.FollowStatus;
 import monochrome.libri.follow.repository.FollowRepository;
 import monochrome.libri.home.dto.response.HomeResponseDto;
@@ -33,9 +35,12 @@ class HomeServiceImplTest {
         MemberService memberService = mock(MemberService.class);
         FollowRepository followRepository = mock(FollowRepository.class);
         ShelfRepository shelfRepository = mock(ShelfRepository.class);
+        BookRepository bookRepository = mock(BookRepository.class);
         Clock clock = Clock.fixed(Instant.parse("2024-01-10T00:00:00Z"), ZoneOffset.UTC);
 
-        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, clock);
+        when(bookRepository.findRecommendedBooks(null, 3)).thenReturn(List.of());
+
+        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, bookRepository, clock);
 
         HomeResponseDto response = service.getHome(null);
 
@@ -51,6 +56,7 @@ class HomeServiceImplTest {
         MemberService memberService = mock(MemberService.class);
         FollowRepository followRepository = mock(FollowRepository.class);
         ShelfRepository shelfRepository = mock(ShelfRepository.class);
+        BookRepository bookRepository = mock(BookRepository.class);
         Clock clock = Clock.fixed(Instant.parse("2024-01-10T00:00:00Z"), ZoneOffset.UTC);
 
         Member member = TestFixtures.member(1L);
@@ -77,14 +83,20 @@ class HomeServiceImplTest {
                 .thenReturn(List.of());
         when(shelfRepository.findShelfBooksByStatus(eq(1L), eq(ShelfStatus.FINISHED), eq(3)))
                 .thenReturn(List.of());
+        when(bookRepository.findRecommendedBooks(1L, 3))
+                .thenReturn(List.of(TestFixtures.book(30L, 320)));
 
-        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, clock);
+        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, bookRepository, clock);
         HomeResponseDto response = service.getHome(1L);
 
         assertThat(response.me().followerCount()).isEqualTo(4);
         assertThat(response.me().followingCount()).isEqualTo(7);
+        assertThat(response.me().unreadNotiCount()).isEqualTo(6);
         assertThat(response.shelfSummary().wantToReadCount()).isEqualTo(1);
         assertThat(response.readingBooks()).hasSize(1);
+        assertThat(response.recommendations()).hasSize(1);
+        assertThat(response.recommendations().get(0).bookId()).isEqualTo(30L);
+        assertThat(response.recommendations().get(0).badgeText()).isEqualTo("리뷰 인기");
         HomeResponseDto.ReadingBook book = response.readingBooks().get(0);
         assertThat(book.progressPercent()).isEqualTo(25);
         assertThat(book.readingDays()).isEqualTo(3);
@@ -95,6 +107,7 @@ class HomeServiceImplTest {
         MemberService memberService = mock(MemberService.class);
         FollowRepository followRepository = mock(FollowRepository.class);
         ShelfRepository shelfRepository = mock(ShelfRepository.class);
+        BookRepository bookRepository = mock(BookRepository.class);
         Clock clock = Clock.fixed(Instant.parse("2024-01-10T00:00:00Z"), ZoneOffset.UTC);
 
         Member member = TestFixtures.member(1L);
@@ -121,11 +134,13 @@ class HomeServiceImplTest {
                 .thenReturn(List.of());
         when(shelfRepository.findShelfBooksByStatus(eq(1L), eq(ShelfStatus.FINISHED), eq(3)))
                 .thenReturn(List.of());
+        when(bookRepository.findRecommendedBooks(1L, 3)).thenReturn(List.of());
 
-        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, clock);
+        HomeServiceImpl service = new HomeServiceImpl(memberService, followRepository, shelfRepository, bookRepository, clock);
         HomeResponseDto response = service.getHome(1L);
 
         assertThat(response.readingBooks()).hasSize(1);
         assertThat(response.readingBooks().get(0).progressPercent()).isEqualTo(25);
+        assertThat(response.me().unreadNotiCount()).isEqualTo(1);
     }
 }

--- a/src/test/java/monochrome/libri/inquiry/service/InquiryServiceImplTest.java
+++ b/src/test/java/monochrome/libri/inquiry/service/InquiryServiceImplTest.java
@@ -120,6 +120,33 @@ class InquiryServiceImplTest {
         assertThat(response.totalCount()).isEqualTo(1L);
         assertThat(response.content()).hasSize(1);
         assertThat(response.content().get(0).memberId()).isEqualTo(1L);
+        assertThat(response.content().get(0).contentPreview()).isEqualTo("content");
+    }
+
+    @Test
+    void getAllInquiries_summarizesLongContent() {
+        InquiryRepository inquiryRepository = mock(InquiryRepository.class);
+        MemberService memberService = mock(MemberService.class);
+        InquiryServiceImpl service = new InquiryServiceImpl(inquiryRepository, memberService);
+
+        Member owner = member(1L, Role.USER);
+        Member admin = member(99L, Role.ADMIN);
+        Inquiry inquiry = Inquiry.builder()
+                .id(10L)
+                .member(owner)
+                .title("title")
+                .content("0123456789012345678901234567890123456789EXTRA")
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        when(memberService.getMemberById(99L)).thenReturn(Optional.of(admin));
+        when(inquiryRepository.findAll(any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(inquiry), PageRequest.of(0, 20), 1));
+        when(inquiryRepository.count()).thenReturn(1L);
+
+        var response = service.getAllInquiries(99L, PageRequest.of(0, 20));
+
+        assertThat(response.content().get(0).contentPreview()).isEqualTo("0123456789012345678901234567890123456789...");
     }
 
     @Test

--- a/src/test/java/monochrome/libri/member/controller/MemberControllerTest.java
+++ b/src/test/java/monochrome/libri/member/controller/MemberControllerTest.java
@@ -1,12 +1,18 @@
 package monochrome.libri.member.controller;
 
 import monochrome.libri.TestFixtures;
+import monochrome.libri.block.dto.response.BlockedMemberListResponseDto;
+import monochrome.libri.block.service.BlockService;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.global.security.UserPrincipal;
 import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.dto.request.MemberUpdateRequestDto;
 import monochrome.libri.member.dto.request.NicknameUpdateRequestDto;
 import monochrome.libri.member.dto.request.PrivacyUpdateRequestDto;
+import monochrome.libri.member.dto.request.ProfileImageUpdateRequestDto;
+import monochrome.libri.member.dto.response.MemberPrivacyResponseDto;
+import monochrome.libri.member.dto.response.MemberProfileResponseDto;
+import monochrome.libri.member.dto.response.MemberResponseDto;
 import monochrome.libri.member.service.MemberService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +34,9 @@ class MemberControllerTest {
     @Mock
     private MemberService memberService;
 
+    @Mock
+    private BlockService blockService;
+
     @InjectMocks
     private MemberController controller;
 
@@ -41,15 +50,60 @@ class MemberControllerTest {
     @Test
     void getMe_returnsAuthenticatedMember() {
         UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
-        Member member = TestFixtures.member(1L);
+        MemberResponseDto member = new MemberResponseDto(1L, null, "user1@test.com", "nick1", "/profile/1", false, 2L, 3L);
 
-        when(memberService.getMemberById(1L)).thenReturn(Optional.of(member));
+        when(memberService.getMyProfile(1L)).thenReturn(member);
 
         var response = controller.getMe(principal);
 
-        verify(memberService).getMemberById(1L);
+        verify(memberService).getMyProfile(1L);
         assertThat(response.getBody().data().id()).isEqualTo(1L);
-        assertThat(response.getBody().data().email()).isEqualTo(member.getEmail());
+        assertThat(response.getBody().data().email()).isEqualTo(member.email());
+        assertThat(response.getBody().data().followerCount()).isEqualTo(2L);
+    }
+
+    @Test
+    void getMyPrivacy_returnsPrivateAccountFlag() {
+        UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
+        when(memberService.getMyPrivacy(1L)).thenReturn(new MemberPrivacyResponseDto(1L, true));
+
+        var response = controller.getMyPrivacy(principal);
+
+        verify(memberService).getMyPrivacy(1L);
+        assertThat(response.getBody().data().privateAccount()).isTrue();
+    }
+
+    @Test
+    void getMemberProfile_returnsRequestedMemberProfile() {
+        UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
+        MemberProfileResponseDto profile = new MemberProfileResponseDto(2L, "user2", "nick2", "/profile/2", true, 4L, 5L, false, true);
+        when(memberService.getMemberProfile(1L, 2L)).thenReturn(profile);
+
+        var response = controller.getMemberProfile(2L, principal);
+
+        verify(memberService).getMemberProfile(1L, 2L);
+        assertThat(response.getBody().data().following()).isTrue();
+        assertThat(response.getBody().data().privateAccount()).isTrue();
+    }
+
+    @Test
+    void blockMember_requiresAuth() {
+        assertThatThrownBy(() -> controller.blockMember(2L, null))
+                .isInstanceOf(LibriException.class);
+        verifyNoInteractions(blockService);
+    }
+
+    @Test
+    void getMyBlockedMembers_returnsBlockedList() {
+        UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
+        when(blockService.getBlockedMembers(eq(1L), any())).thenReturn(
+                new BlockedMemberListResponseDto(1L, List.of(), false, 0, 20)
+        );
+
+        var response = controller.getMyBlockedMembers(principal, 0, 20);
+
+        assertThat(response.getBody().data().totalCount()).isEqualTo(1L);
+        verify(blockService).getBlockedMembers(eq(1L), any());
     }
 
     @Test
@@ -66,8 +120,10 @@ class MemberControllerTest {
         UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
         Member updated = TestFixtures.member(1L);
         updated.updateMember(null, "newNick", null, null, null);
+        MemberResponseDto responseDto = new MemberResponseDto(1L, updated.getProvider(), updated.getEmail(), "newNick", updated.getProfilePath(), false, 2L, 3L);
 
         when(memberService.updateMember(eq(1L), any(MemberUpdateRequestDto.class))).thenReturn(updated);
+        when(memberService.getMyProfile(1L)).thenReturn(responseDto);
 
         var response = controller.updateNickname(principal, new NicknameUpdateRequestDto("newNick"));
 
@@ -75,6 +131,7 @@ class MemberControllerTest {
         verify(memberService).updateMember(eq(1L), captor.capture());
         assertThat(captor.getValue().nickname()).isEqualTo("newNick");
         assertThat(response.getBody().data().nickname()).isEqualTo("newNick");
+        assertThat(response.getBody().data().followingCount()).isEqualTo(3L);
     }
 
     @Test
@@ -82,8 +139,10 @@ class MemberControllerTest {
         UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
         Member updated = TestFixtures.member(1L);
         updated.updateMember(null, null, null, null, true);
+        MemberResponseDto responseDto = new MemberResponseDto(1L, updated.getProvider(), updated.getEmail(), updated.getNickname(), updated.getProfilePath(), true, 2L, 3L);
 
         when(memberService.updateMember(eq(1L), any(MemberUpdateRequestDto.class))).thenReturn(updated);
+        when(memberService.getMyProfile(1L)).thenReturn(responseDto);
 
         var response = controller.updatePrivacy(principal, new PrivacyUpdateRequestDto(true));
 
@@ -91,5 +150,32 @@ class MemberControllerTest {
         verify(memberService).updateMember(eq(1L), captor.capture());
         assertThat(captor.getValue().privateAccount()).isTrue();
         assertThat(response.getBody().data().privateAccount()).isTrue();
+    }
+
+    @Test
+    void updateProfileImage_updatesProfilePathForAuthenticatedUser() {
+        UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
+        Member updated = TestFixtures.member(1L);
+        updated.updateMember(null, null, null, "https://bucket/path.png", null);
+        MemberResponseDto responseDto = new MemberResponseDto(
+                1L,
+                updated.getProvider(),
+                updated.getEmail(),
+                updated.getNickname(),
+                "https://bucket/path.png",
+                false,
+                2L,
+                3L
+        );
+
+        when(memberService.updateMember(eq(1L), any(MemberUpdateRequestDto.class))).thenReturn(updated);
+        when(memberService.getMyProfile(1L)).thenReturn(responseDto);
+
+        var response = controller.updateProfileImage(principal, new ProfileImageUpdateRequestDto("https://bucket/path.png"));
+
+        ArgumentCaptor<MemberUpdateRequestDto> captor = ArgumentCaptor.forClass(MemberUpdateRequestDto.class);
+        verify(memberService).updateMember(eq(1L), captor.capture());
+        assertThat(captor.getValue().profilePath()).isEqualTo("https://bucket/path.png");
+        assertThat(response.getBody().data().profilePath()).isEqualTo("https://bucket/path.png");
     }
 }

--- a/src/test/java/monochrome/libri/note/service/NoteServiceImplTest.java
+++ b/src/test/java/monochrome/libri/note/service/NoteServiceImplTest.java
@@ -1,6 +1,7 @@
 package monochrome.libri.note.service;
 
 import monochrome.libri.TestFixtures;
+import monochrome.libri.block.service.BlockService;
 import monochrome.libri.comment.repository.NoteCommentRepository;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.member.domain.Member;
@@ -51,6 +52,9 @@ class NoteServiceImplTest {
     @Mock
     private NoteCommentRepository noteCommentRepository;
 
+    @Mock
+    private BlockService blockService;
+
     @InjectMocks
     private monochrome.libri.note.service.impl.NoteServiceImpl service;
 
@@ -82,6 +86,20 @@ class NoteServiceImplTest {
         Note note = TestFixtures.note(10L, shelf, owner, true);
 
         when(noteRepository.findWithBookById(10L)).thenReturn(Optional.of(note));
+        when(blockService.hasBlockRelation(999L, 1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getNoteDetail(10L, 999L))
+                .isInstanceOf(LibriException.class);
+    }
+
+    @Test
+    void getNoteDetail_deniesBlockedMember() {
+        Member owner = TestFixtures.member(1L);
+        Shelf shelf = TestFixtures.shelf(2L, owner, TestFixtures.book(3L, 100));
+        Note note = TestFixtures.note(10L, shelf, owner, false);
+
+        when(noteRepository.findWithBookById(10L)).thenReturn(Optional.of(note));
+        when(blockService.hasBlockRelation(999L, 1L)).thenReturn(true);
 
         assertThatThrownBy(() -> service.getNoteDetail(10L, 999L))
                 .isInstanceOf(LibriException.class);

--- a/src/test/java/monochrome/libri/shelf/service/ShelfServiceImplTest.java
+++ b/src/test/java/monochrome/libri/shelf/service/ShelfServiceImplTest.java
@@ -15,12 +15,13 @@ import monochrome.libri.shelf.dto.request.ShelfCreateRequestDto;
 import monochrome.libri.shelf.dto.request.ShelfUpdateRequestDto;
 import monochrome.libri.shelf.repository.ShelfRepository;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -211,5 +212,76 @@ class ShelfServiceImplTest {
 
         assertThat(response.content()).hasSize(1);
         assertThat(response.content().get(0).progressPercent()).isEqualTo(20);
+    }
+
+    @Test
+    void getReadingCalendar_returnsStartedAndFinishedBooksByDay() {
+        ShelfRepository shelfRepository = mock(ShelfRepository.class);
+        ReviewService reviewService = mock(ReviewService.class);
+        MemberService memberService = mock(MemberService.class);
+        BookRepository bookRepository = mock(BookRepository.class);
+        Clock clock = Clock.fixed(Instant.parse("2024-03-10T00:00:00Z"), ZoneOffset.UTC);
+        ShelfServiceImpl service = new ShelfServiceImpl(shelfRepository, reviewService, memberService, bookRepository, clock);
+
+        when(shelfRepository.findCalendarRowsByMemberIdAndDateRange(
+                1L,
+                LocalDate.of(2024, 3, 1),
+                LocalDate.of(2024, 3, 31)
+        )).thenReturn(List.of(
+                new monochrome.libri.shelf.dto.ShelfCalendarRow(
+                        10L,
+                        20L,
+                        "title",
+                        "/cover",
+                        LocalDate.of(2024, 3, 5),
+                        LocalDate.of(2024, 3, 20),
+                        ShelfStatus.FINISHED
+                )
+        ));
+
+        var response = service.getReadingCalendar(1L, YearMonth.of(2024, 3));
+
+        assertThat(response.days()).hasSize(31);
+        assertThat(response.days().get(4).startedBooks()).hasSize(1);
+        assertThat(response.days().get(19).finishedBooks()).hasSize(1);
+        assertThat(response.days().get(4).startedBooks().get(0).coverUrl()).isEqualTo("/cover");
+    }
+
+    @Test
+    void getReadingStatistics_returnsYearlyAndMonthlyCounts() {
+        ShelfRepository shelfRepository = mock(ShelfRepository.class);
+        ReviewService reviewService = mock(ReviewService.class);
+        MemberService memberService = mock(MemberService.class);
+        BookRepository bookRepository = mock(BookRepository.class);
+        Clock clock = Clock.fixed(Instant.parse("2024-03-10T00:00:00Z"), ZoneOffset.UTC);
+        ShelfServiceImpl service = new ShelfServiceImpl(shelfRepository, reviewService, memberService, bookRepository, clock);
+
+        when(shelfRepository.countByMemberIdAndStartDateBetween(
+                1L,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 12, 31)
+        )).thenReturn(4L);
+        when(shelfRepository.countByMemberIdAndStatusAndEndDateBetween(
+                1L,
+                ShelfStatus.FINISHED,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 12, 31)
+        )).thenReturn(3L);
+        when(shelfRepository.countFinishedBooksByYear(1L)).thenReturn(List.of(
+                new monochrome.libri.shelf.dto.YearCountRow(2023, 2L),
+                new monochrome.libri.shelf.dto.YearCountRow(2024, 3L)
+        ));
+        when(shelfRepository.countFinishedBooksByMonth(1L, 2024)).thenReturn(List.of(
+                new monochrome.libri.shelf.dto.MonthCountRow(1, 1L),
+                new monochrome.libri.shelf.dto.MonthCountRow(3, 2L)
+        ));
+
+        var response = service.getReadingStatistics(1L, 2024);
+
+        assertThat(response.totalStartedCount()).isEqualTo(4L);
+        assertThat(response.totalFinishedCount()).isEqualTo(3L);
+        assertThat(response.yearlyFinishedCounts()).hasSize(2);
+        assertThat(response.monthlyFinishedCounts().get(0).count()).isEqualTo(1L);
+        assertThat(response.monthlyCumulativeFinishedCounts().get(2).count()).isEqualTo(3L);
     }
 }

--- a/src/test/java/monochrome/libri/storage/controller/FileControllerTest.java
+++ b/src/test/java/monochrome/libri/storage/controller/FileControllerTest.java
@@ -1,0 +1,58 @@
+package monochrome.libri.storage.controller;
+
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.global.security.UserPrincipal;
+import monochrome.libri.storage.dto.request.PresignedUploadRequestDto;
+import monochrome.libri.storage.dto.response.PresignedUploadResponseDto;
+import monochrome.libri.storage.service.PresignedUploadService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileControllerTest {
+
+    @Mock
+    private PresignedUploadService presignedUploadService;
+
+    @InjectMocks
+    private FileController controller;
+
+    @Test
+    void createPresignedUploadUrl_requiresAuth() {
+        PresignedUploadRequestDto request = new PresignedUploadRequestDto("profiles", "me.png", "image/png");
+
+        assertThatThrownBy(() -> controller.createPresignedUploadUrl(null, request))
+                .isInstanceOf(LibriException.class);
+        verifyNoInteractions(presignedUploadService);
+    }
+
+    @Test
+    void createPresignedUploadUrl_returnsPresignedInfo() {
+        UserPrincipal principal = new UserPrincipal(1L, null, List.of(), true);
+        PresignedUploadRequestDto request = new PresignedUploadRequestDto("profiles", "me.png", "image/png");
+        PresignedUploadResponseDto responseDto = new PresignedUploadResponseDto(
+                "https://upload-url",
+                "profiles/1/key.png",
+                "https://file-url",
+                300
+        );
+        when(presignedUploadService.createPresignedUploadUrl(1L, request)).thenReturn(responseDto);
+
+        var response = controller.createPresignedUploadUrl(principal, request);
+
+        verify(presignedUploadService).createPresignedUploadUrl(1L, request);
+        assertThat(response.getBody().data().uploadUrl()).isEqualTo("https://upload-url");
+        assertThat(response.getBody().data().key()).isEqualTo("profiles/1/key.png");
+    }
+}


### PR DESCRIPTION
- 회원 기능 확장
  - 타 유저 프로필 조회 API 추가
  - 내 비공개 여부 조회 API 추가
  - 내 프로필 응답에 팔로워/팔로잉 수 추가
  - 프로필 이미지 경로 저장 API 추가

- 홈 기능 보강
  - unreadNotiCount를 책장 총 권수 기준으로 변경
  - 추천 도서 로직 추가

- 문의/책/댓글 기능 보강
  - 문의 목록에 본문 요약 필드 추가
  - 책 상세 응답에 totalPage 추가
  - 댓글 신고 API 추가

- 차단 기능 추가
  - 회원 차단/차단 해제 API 추가
  - 내 차단 목록 조회 API 추가
  - 차단 관계에 따른 프로필/팔로우/노트/댓글 접근 제한 적용

- 독서 달력/통계 API 추가
  - 월별 독서 시작/완독 달력 응답 추가
  - 연도별 완독 수, 월별 완독 수, 누적 완독 통계 추가

- S3 업로드 기반 추가
  - presigned upload URL 발급 API 추가
  - S3 설정 및 업로드 관련 구성 추가

- DB 반영 사항
  - member_block 테이블 추가
  - note_comment_report 테이블 추가