### PR TITLE
20260617

### DIFF
--- a/docs/spec/api-overview.md
+++ b/docs/spec/api-overview.md
@@ -124,6 +124,195 @@
 - 로그인 성공 시 access/refresh token 둘 다 저장
 - 이후 인증 API는 access token만 헤더에 사용
 
+### 소셜 로그인
+
+- `POST /auth/login/social`
+- Auth: 없음
+
+지원 provider:
+
+- `KAKAO`
+- `APPLE`
+
+요청 규칙:
+
+- `provider=KAKAO` 이면 `accessToken` 필수, `idToken` 생략
+- `provider=APPLE` 이면 `idToken` 필수, `accessToken` 생략
+- 토큰은 프론트가 각 SDK 또는 네이티브 로그인 결과에서 받아서 백엔드로 전달
+
+동작 방식:
+
+- 이미 연동된 소셜 계정이면 기존 회원으로 로그인
+- 같은 이메일의 기존 회원이 있으면 해당 회원에 자동 연동 후 로그인
+- 일치 회원이 없으면 새 회원 생성 후 로그인
+
+입력:
+
+- `provider`
+- `accessToken`
+- `idToken`
+
+카카오 요청 예시:
+
+```json
+{
+  "provider": "KAKAO",
+  "accessToken": "kakao-access-token"
+}
+```
+
+애플 요청 예시:
+
+```json
+{
+  "provider": "APPLE",
+  "idToken": "eyJraWQiOiJ...apple-id-token"
+}
+```
+
+출력:
+
+- `tokenType`
+- `accessToken`
+- `refreshToken`
+- `memberResponseDto`
+
+성공 응답 예시:
+
+```json
+{
+  "success": true,
+  "code": "OK",
+  "message": null,
+  "data": {
+    "tokenType": "Bearer",
+    "accessToken": "ACCESS_TOKEN",
+    "refreshToken": "REFRESH_TOKEN",
+    "memberResponseDto": {
+      "id": 12,
+      "provider": "EMAIL",
+      "email": "user@test.com",
+      "nickname": "nick12",
+      "profilePath": "/profile/12",
+      "privateAccount": false,
+      "followerCount": 0,
+      "followingCount": 0
+    }
+  }
+}
+```
+
+대표 에러:
+
+- `A005 INVALID_SOCIAL_TOKEN`
+- `C002 INVALID_INPUT_VALUE`
+- `A001 AUTHENTICATION_FAILED`
+
+프론트 포인트:
+
+- 성공 시 이메일 로그인과 동일하게 `accessToken`, `refreshToken` 둘 다 저장
+- `tokenType`은 현재 `Bearer`로 고정이지만 그대로 사용
+- 이후 인증 API는 `Authorization: Bearer {accessToken}` 헤더 사용
+- `memberResponseDto.provider`는 회원의 기본 가입 타입이며, 자동 연동된 경우 `EMAIL`일 수 있음
+
+프론트 구현 순서:
+
+1. 카카오/애플 SDK로 사용자 로그인 진행
+2. SDK 결과에서 provider별 토큰 획득
+3. 백엔드 `/api/v1/auth/login/social` 호출
+4. 응답의 `accessToken`, `refreshToken` 저장
+5. 이후 API부터 access token만 Authorization 헤더에 첨부
+
+카카오 프론트 예시:
+
+```ts
+const kakaoAccessToken = await getKakaoAccessTokenFromSdk();
+
+const response = await fetch("/api/v1/auth/login/social", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    provider: "KAKAO",
+    accessToken: kakaoAccessToken,
+  }),
+});
+
+const result = await response.json();
+
+if (!response.ok || !result.success) {
+  throw new Error(result.message ?? "카카오 로그인에 실패했습니다.");
+}
+
+const { tokenType, accessToken, refreshToken, memberResponseDto } = result.data;
+localStorage.setItem("accessToken", accessToken);
+localStorage.setItem("refreshToken", refreshToken);
+```
+
+애플 프론트 예시:
+
+```ts
+const appleIdToken = await getAppleIdTokenFromSdk();
+
+const response = await fetch("/api/v1/auth/login/social", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    provider: "APPLE",
+    idToken: appleIdToken,
+  }),
+});
+
+const result = await response.json();
+
+if (!response.ok || !result.success) {
+  throw new Error(result.message ?? "애플 로그인에 실패했습니다.");
+}
+
+const { accessToken, refreshToken } = result.data;
+localStorage.setItem("accessToken", accessToken);
+localStorage.setItem("refreshToken", refreshToken);
+```
+
+에러 처리 가이드:
+
+- `A005`: 소셜 토큰 만료, 위조, 잘못된 provider 토큰. 프론트는 SDK 로그인부터 다시 시도
+- `C002`: body 누락 또는 잘못된 요청. 프론트 버그 또는 잘못된 파라미터
+- `A001`: 이미 다른 회원에 연동된 소셜 계정 등 인증 불일치 상황
+
+소셜 로그인 예외 케이스 표:
+
+| 상황 | HTTP | code | 프론트 처리 |
+| --- | --- | --- | --- |
+| `provider` 누락 | 400 | `C002` | 요청 body 구성 오류 수정 |
+| `provider=KAKAO`인데 `accessToken` 없음 | 400 | `C002` | 카카오 SDK 결과 확인 후 재요청 |
+| `provider=APPLE`인데 `idToken` 없음 | 400 | `C002` | 애플 SDK 결과 확인 후 재요청 |
+| 지원하지 않는 provider 전달 | 400 | `C002` | 프론트 상수값 확인 |
+| 카카오 access token 만료/위조 | 401 | `A005` | 카카오 로그인부터 다시 시작 |
+| 애플 id token 만료/서명 불일치 | 401 | `A005` | 애플 로그인부터 다시 시작 |
+| 애플 audience(client id) 불일치 | 401 | `A005` | 앱 번들 ID, 서비스 ID, 환경변수 설정 확인 |
+| 이미 다른 회원에 연결된 소셜 계정으로 충돌 | 401 | `A001` | 자동 재시도하지 말고 문의/안내 처리 |
+| 탈퇴 회원에 연결된 소셜 계정 로그인 | 401 | `M003` | 재가입 정책 확인 필요. 현재는 로그인 실패 처리 |
+| 소셜 provider에서 이메일 미제공 | 200 | `OK` | 정상 로그인 가능. 이메일 없이 가입/로그인될 수 있음 |
+| 같은 이메일의 기존 계정 발견 | 200 | `OK` | 정상 로그인. 백엔드가 자동 연동 처리 |
+
+프론트 에러 메시지 처리 권장:
+
+- `C002`는 개발 중이면 필드 매핑 오류를 우선 의심
+- `A005`는 사용자에게 "로그인이 만료되었어요. 다시 시도해주세요." 수준으로 안내
+- `A001`은 자동 연동 충돌 가능성이 있으므로 일반 재시도보다 고객센터 문의 문구가 안전
+- `M003`은 현재 메시지가 이메일 로그인과 공용일 수 있으므로, 필요하면 추후 소셜 전용 코드 분리 검토
+
+주의:
+
+- 애플은 이메일이 항상 내려오지 않을 수 있다
+- 카카오는 이메일 동의가 없으면 이메일이 비어 있을 수 있다
+- 백엔드는 이메일이 없더라도 provider 식별자로 회원 생성/로그인 가능
+- 자동 연동은 이메일이 정확히 일치할 때만 수행한다
+
 ### 액세스 토큰 재발급
 
 - `POST /auth/refresh`

--- a/docs/spec/auth.md
+++ b/docs/spec/auth.md
@@ -13,6 +13,18 @@
 - 소셜 계정(passwordHash == null)은 INVALID_LOGIN으로 실패한다.
 - 로그인 시 비밀번호 해시를 검증한다.
 
+### Login (Social)
+- Social 로그인은 provider별 토큰 검증에 성공해야 한다.
+- 현재 지원 provider는 `KAKAO`, `APPLE`이다.
+- `KAKAO`는 `accessToken`으로 사용자 정보를 조회한다.
+- `APPLE`는 `idToken`을 Apple 공개키로 검증한다.
+- 이미 연동된 `(provider, providerUserId)`가 있으면 해당 회원으로 로그인한다.
+- 같은 이메일의 기존 회원이 있으면 소셜 계정을 자동 연동한다.
+- 이메일 일치 회원이 없으면 새 회원을 생성한다.
+- 탈퇴 회원(memberStatus=DELETE)은 INVALID_LOGIN으로 실패한다.
+- provider 토큰 검증 실패는 INVALID_SOCIAL_TOKEN으로 실패한다.
+- 이미 다른 회원에 연동된 provider 식별자 충돌은 AUTHENTICATION_FAILED로 실패한다.
+
 ### JWT (Access Token)
 - 로그인 성공 시 Access Token을 발급한다.
 - Access Token은 `sub=memberId`를 포함한다.
@@ -65,4 +77,4 @@
   - verification token 발급/만료/재발송/rate limit
   - 인증 완료 시 emailVerified=true 및 상태 전환(PENDING -> ACTIVE)
 - JWT Refresh Token(재발급, 탈취 대응, 로그아웃 정책)
-- 소셜 로그인(구글/카카오/애플) 정책 및 중복/연동 정책
+- 소셜 로그인(구글) 추가 검토

--- a/src/main/java/monochrome/libri/block/repository/MemberBlockRepository.java
+++ b/src/main/java/monochrome/libri/block/repository/MemberBlockRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,4 +25,8 @@ public interface MemberBlockRepository extends JpaRepository<MemberBlock, Long> 
     Slice<MemberBlock> findByBlockerIdOrderByCreatedDateDesc(long blockerId, Pageable pageable);
 
     long countByBlockerId(long blockerId);
+
+    @Query("select case when mb.blocker.id = :memberId then mb.blocked.id else mb.blocker.id end " +
+            "from MemberBlock mb where mb.blocker.id = :memberId or mb.blocked.id = :memberId")
+    List<Long> findBlockedRelationMemberIds(@Param("memberId") long memberId);
 }

--- a/src/main/java/monochrome/libri/block/service/BlockService.java
+++ b/src/main/java/monochrome/libri/block/service/BlockService.java
@@ -3,9 +3,12 @@ package monochrome.libri.block.service;
 import monochrome.libri.block.dto.response.BlockedMemberListResponseDto;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Set;
+
 public interface BlockService {
     void blockMember(long blockerMemberId, long blockedMemberId);
     void unblockMember(long blockerMemberId, long blockedMemberId);
     BlockedMemberListResponseDto getBlockedMembers(long blockerMemberId, Pageable pageable);
     boolean hasBlockRelation(long memberId, long otherMemberId);
+    Set<Long> getBlockedRelationMemberIds(long memberId);
 }

--- a/src/main/java/monochrome/libri/block/service/impl/BlockServiceImpl.java
+++ b/src/main/java/monochrome/libri/block/service/impl/BlockServiceImpl.java
@@ -90,6 +90,14 @@ public class BlockServiceImpl implements BlockService {
                 || memberBlockRepository.existsByBlockerIdAndBlockedId(otherMemberId, memberId);
     }
 
+    @Override
+    public java.util.Set<Long> getBlockedRelationMemberIds(long memberId) {
+        if (memberId <= 0) {
+            return java.util.Set.of();
+        }
+        return new java.util.HashSet<>(memberBlockRepository.findBlockedRelationMemberIds(memberId));
+    }
+
     private Member getMember(long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new LibriException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/monochrome/libri/book/controller/BookController.java
+++ b/src/main/java/monochrome/libri/book/controller/BookController.java
@@ -9,6 +9,8 @@ import monochrome.libri.book.dto.response.BookDetailResponseDto;
 import monochrome.libri.book.dto.response.BookSliceResponseDto;
 import monochrome.libri.book.service.BookService;
 import monochrome.libri.search.service.SearchService;
+import monochrome.libri.note.dto.response.BookNoteSliceResponseDto;
+import monochrome.libri.note.service.NoteService;
 import monochrome.libri.global.swagger.ApiErrorCodes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,10 +33,12 @@ public class BookController {
 
     private final BookService bookService;
     private final SearchService searchService;
+    private final NoteService noteService;
 
-    public BookController(BookService bookService, SearchService searchService) {
+    public BookController(BookService bookService, SearchService searchService, NoteService noteService) {
         this.bookService = bookService;
         this.searchService = searchService;
+        this.noteService = noteService;
     }
 
     @GetMapping
@@ -84,6 +88,32 @@ public class BookController {
     ) {
         Long memberId = userPrincipal == null ? null : userPrincipal.getMemberId();
         BookDetailResponseDto response = bookService.getBookDetail(bookId, memberId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/{bookId}/notes")
+    @Operation(
+            summary = "도서 노트 목록 조회",
+            description = "도서에 등록된 공개 노트를 페이지네이션으로 조회합니다. 비밀 노트와 차단 관계 회원의 노트는 제외됩니다."
+    )
+    @ApiErrorCodes({
+            ErrorCode.BOOK_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    public ResponseEntity<ApiResponse<BookNoteSliceResponseDto>> getNotesByBook(
+            @PathVariable long bookId,
+            @AuthenticationPrincipal monochrome.libri.global.security.UserPrincipal userPrincipal,
+            @Parameter(description = "페이지(0부터)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        if (page < 0 || size <= 0) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        long memberId = userPrincipal == null ? 0L : userPrincipal.getMemberId();
+        Pageable pageable = PageRequest.of(page, size);
+        BookNoteSliceResponseDto response = noteService.getPublicNotesByBook(bookId, memberId, pageable);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/src/main/java/monochrome/libri/follow/service/FollowServiceImpl.java
+++ b/src/main/java/monochrome/libri/follow/service/FollowServiceImpl.java
@@ -1,7 +1,6 @@
 package monochrome.libri.follow.service;
 
 import monochrome.libri.block.service.BlockService;
-import lombok.extern.slf4j.Slf4j;
 import monochrome.libri.follow.domain.Follow;
 import monochrome.libri.follow.domain.FollowStatus;
 import monochrome.libri.follow.dto.MemberSummaryDto;
@@ -13,14 +12,17 @@ import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.service.MemberService;
 import monochrome.libri.notification.domain.NotificationType;
 import monochrome.libri.notification.service.NotificationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 public class FollowServiceImpl implements FollowService{
+
+    private static final Logger log = LoggerFactory.getLogger(FollowServiceImpl.class);
 
     private final FollowRepository followRepository;
     private final MemberService memberService;

--- a/src/main/java/monochrome/libri/global/exception/ErrorCode.java
+++ b/src/main/java/monochrome/libri/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 리프레시 토큰입니다."),
     TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "A004", "토큰 타입이 올바르지 않습니다."),
+    INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "유효하지 않은 소셜 로그인 토큰입니다."),
 
     // 회원 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회원입니다."),

--- a/src/main/java/monochrome/libri/member/config/SocialLoginConfig.java
+++ b/src/main/java/monochrome/libri/member/config/SocialLoginConfig.java
@@ -1,0 +1,25 @@
+package monochrome.libri.member.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(SocialLoginProperties.class)
+public class SocialLoginConfig {
+
+    @Bean
+    public RestClient kakaoSocialRestClient(SocialLoginProperties properties) {
+        return RestClient.builder()
+                .baseUrl(properties.kakao().baseUrl())
+                .build();
+    }
+
+    @Bean
+    public RestClient appleSocialRestClient(SocialLoginProperties properties) {
+        return RestClient.builder()
+                .baseUrl(properties.apple().baseUrl())
+                .build();
+    }
+}

--- a/src/main/java/monochrome/libri/member/config/SocialLoginProperties.java
+++ b/src/main/java/monochrome/libri/member/config/SocialLoginProperties.java
@@ -1,0 +1,23 @@
+package monochrome.libri.member.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.social")
+public record SocialLoginProperties(
+        Kakao kakao,
+        Apple apple
+) {
+    public record Kakao(
+            String baseUrl
+    ) {
+    }
+
+    public record Apple(
+            String baseUrl,
+            String issuer,
+            List<String> clientIds
+    ) {
+    }
+}

--- a/src/main/java/monochrome/libri/member/controller/AuthController.java
+++ b/src/main/java/monochrome/libri/member/controller/AuthController.java
@@ -8,12 +8,17 @@ import monochrome.libri.global.swagger.ApiErrorCodes;
 import monochrome.libri.member.dto.request.EmailLoginRequestDto;
 import monochrome.libri.member.dto.request.EmailSignUpRequestDto;
 import monochrome.libri.member.dto.request.RefreshTokenRequestDto;
-import monochrome.libri.member.dto.request.SocialSignUpRequestDto;
+import monochrome.libri.member.dto.request.SocialLoginRequestDto;
 import monochrome.libri.member.dto.response.LoginResponseDto;
+import monochrome.libri.member.dto.response.LoginApiResponseDoc;
 import monochrome.libri.member.dto.response.MemberResponseDto;
 import monochrome.libri.member.dto.response.TokenRefreshResponseDto;
 import monochrome.libri.member.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -64,17 +69,190 @@ public class AuthController {
     public ResponseEntity<ApiResponse<LoginResponseDto>> loginByEmail(
             @Valid @RequestBody EmailLoginRequestDto request
     ) {
-        MemberResponseDto memberResponse = authService.loginByEmail(request);
-        var tokenPair = jwtTokenService.issueTokenPair(memberResponse.id());
+        return ResponseEntity.ok(ApiResponse.ok(issueLoginResponse(authService.loginByEmail(request))));
+    }
 
-        LoginResponseDto response = LoginResponseDto.of(
-                tokenPair.tokenType(),
-                tokenPair.accessToken(),
-                tokenPair.refreshToken(),
-                memberResponse
-        );
-
-        return ResponseEntity.ok(ApiResponse.ok(response));
+    @ApiErrorCodes({
+            ErrorCode.INVALID_SOCIAL_TOKEN,
+            ErrorCode.INVALID_INPUT_VALUE
+    })
+    @PostMapping("/login/social")
+    @Operation(
+            summary = "소셜 로그인",
+            description = """
+                    카카오/애플 로그인 후 access/refresh token을 발급합니다.
+                    
+                    요청 규칙:
+                    - provider=KAKAO 이면 accessToken 필수, idToken 생략
+                    - provider=APPLE 이면 idToken 필수, accessToken 생략
+                    
+                    동작 방식:
+                    - 이미 연동된 소셜 계정이면 해당 회원으로 로그인
+                    - 같은 이메일의 기존 회원이 있으면 자동 연동 후 로그인
+                    - 일치 회원이 없으면 새 회원을 생성한 뒤 로그인
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "소셜 로그인 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LoginApiResponseDoc.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "KakaoSocialLoginSuccess",
+                                            summary = "카카오 로그인 성공",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "OK",
+                                                      "message": null,
+                                                      "data": {
+                                                        "tokenType": "Bearer",
+                                                        "accessToken": "ACCESS_TOKEN",
+                                                        "refreshToken": "REFRESH_TOKEN",
+                                                        "memberResponseDto": {
+                                                          "id": 12,
+                                                          "provider": "EMAIL",
+                                                          "email": "user@test.com",
+                                                          "nickname": "nick12",
+                                                          "profilePath": "/profile/12",
+                                                          "privateAccount": false,
+                                                          "followerCount": 0,
+                                                          "followingCount": 0
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "AppleSocialLoginSuccess",
+                                            summary = "애플 로그인 성공",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "OK",
+                                                      "message": null,
+                                                      "data": {
+                                                        "tokenType": "Bearer",
+                                                        "accessToken": "ACCESS_TOKEN",
+                                                        "refreshToken": "REFRESH_TOKEN",
+                                                        "memberResponseDto": {
+                                                          "id": 34,
+                                                          "provider": "APPLE",
+                                                          "email": null,
+                                                          "nickname": "apple_000123",
+                                                          "profilePath": null,
+                                                          "privateAccount": false,
+                                                          "followerCount": 0,
+                                                          "followingCount": 0
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "MissingKakaoAccessToken",
+                                            summary = "카카오 accessToken 누락",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "code": "C002",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "UnsupportedProvider",
+                                            summary = "지원하지 않는 provider",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "code": "C002",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "소셜 토큰 검증 실패 또는 계정 연동 충돌",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "InvalidSocialToken",
+                                            summary = "카카오/애플 토큰 검증 실패",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "code": "A005",
+                                                      "message": "유효하지 않은 소셜 로그인 토큰입니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "AuthenticationConflict",
+                                            summary = "이미 다른 회원에 연동된 소셜 계정",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "code": "A001",
+                                                      "message": "인증에 실패했습니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "WithdrawnMemberSocialLogin",
+                                            summary = "탈퇴 회원 로그인 시도",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "code": "M003",
+                                                      "message": "이메일 또는 비밀번호가 올바르지 않습니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<LoginResponseDto>> loginBySocial(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = """
+                            카카오 예시:
+                            {
+                              "provider": "KAKAO",
+                              "accessToken": "kakao-access-token"
+                            }
+                            
+                            애플 예시:
+                            {
+                              "provider": "APPLE",
+                              "idToken": "apple-id-token"
+                            }
+                            """
+            )
+            @Valid @RequestBody SocialLoginRequestDto request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(issueLoginResponse(authService.loginBySocial(request))));
     }
 
     /**
@@ -117,5 +295,15 @@ public class AuthController {
         authService.logout(request.refreshToken());
         jwtTokenService.revokeRefreshToken(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    private LoginResponseDto issueLoginResponse(MemberResponseDto memberResponse) {
+        var tokenPair = jwtTokenService.issueTokenPair(memberResponse.id());
+        return LoginResponseDto.of(
+                tokenPair.tokenType(),
+                tokenPair.accessToken(),
+                tokenPair.refreshToken(),
+                memberResponse
+        );
     }
 }

--- a/src/main/java/monochrome/libri/member/domain/Member.java
+++ b/src/main/java/monochrome/libri/member/domain/Member.java
@@ -90,4 +90,11 @@ public class Member extends AuditableEntity {
     public void withdraw() {
         this.memberStatus = MemberStatus.DELETE;
     }
+
+    public void verifyEmailFromSocialProvider(boolean emailVerifiedFromProvider) {
+        if (emailVerifiedFromProvider) {
+            this.emailVerifiedFromProvider = true;
+            this.emailVerified = true;
+        }
+    }
 }

--- a/src/main/java/monochrome/libri/member/domain/SocialAccount.java
+++ b/src/main/java/monochrome/libri/member/domain/SocialAccount.java
@@ -1,0 +1,38 @@
+package monochrome.libri.member.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import monochrome.libri.global.domain.AuditableEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "social_account",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_social_account_provider_user", columnNames = {"provider", "providerUserId"}),
+                @UniqueConstraint(name = "uk_social_account_member_provider", columnNames = {"member_id", "provider"})
+        }
+)
+public class SocialAccount extends AuditableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "social_account_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private SignType provider;
+
+    @Column(nullable = false, length = 100)
+    private String providerUserId;
+
+    @Column(nullable = false)
+    private boolean emailVerifiedFromProvider;
+}

--- a/src/main/java/monochrome/libri/member/dto/request/SocialLoginRequestDto.java
+++ b/src/main/java/monochrome/libri/member/dto/request/SocialLoginRequestDto.java
@@ -1,0 +1,25 @@
+package monochrome.libri.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
+import monochrome.libri.member.domain.SignType;
+
+public record SocialLoginRequestDto(
+        @Schema(
+                description = "소셜 로그인 제공자. 현재 KAKAO, APPLE 지원",
+                example = "KAKAO"
+        )
+        @NotNull(message = "소셜 로그인 제공자는 필수입니다.")
+        SignType provider,
+        @Schema(
+                description = "카카오 로그인 후 프론트가 받은 access token. provider=KAKAO 일 때 사용",
+                example = "kakao-access-token"
+        )
+        String accessToken,
+        @Schema(
+                description = "애플 로그인 후 프론트가 받은 id token(JWT). provider=APPLE 일 때 사용",
+                example = "eyJraWQiOiJ...apple-id-token"
+        )
+        String idToken
+) {
+}

--- a/src/main/java/monochrome/libri/member/dto/response/LoginApiResponseDoc.java
+++ b/src/main/java/monochrome/libri/member/dto/response/LoginApiResponseDoc.java
@@ -1,0 +1,16 @@
+package monochrome.libri.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "LoginApiResponse", description = "로그인 성공 응답")
+public record LoginApiResponseDoc(
+        @Schema(description = "성공 여부", example = "true")
+        boolean success,
+        @Schema(description = "공통 성공 코드", example = "OK")
+        String code,
+        @Schema(description = "성공 메시지", nullable = true, example = "null")
+        String message,
+        @Schema(description = "로그인 응답 데이터")
+        LoginResponseDto data
+) {
+}

--- a/src/main/java/monochrome/libri/member/dto/response/LoginResponseDto.java
+++ b/src/main/java/monochrome/libri/member/dto/response/LoginResponseDto.java
@@ -1,9 +1,15 @@
 package monochrome.libri.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record LoginResponseDto(
+        @Schema(description = "토큰 타입", example = "Bearer")
         String tokenType,
+        @Schema(description = "백엔드 access token", example = "ACCESS_TOKEN")
         String accessToken,
+        @Schema(description = "백엔드 refresh token", example = "REFRESH_TOKEN")
         String refreshToken,
+        @Schema(description = "로그인한 회원 정보")
         MemberResponseDto memberResponseDto
 ) {
     public static LoginResponseDto of(

--- a/src/main/java/monochrome/libri/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/monochrome/libri/member/dto/response/MemberResponseDto.java
@@ -1,18 +1,28 @@
 package monochrome.libri.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import monochrome.libri.member.domain.Member;
-import monochrome.libri.member.domain.MemberStatus;
-import monochrome.libri.member.domain.Role;
 import monochrome.libri.member.domain.SignType;
 
 public record MemberResponseDto(
+    @Schema(description = "회원 ID", example = "12")
     long id,
+    @Schema(
+            description = "회원의 기본 가입 타입. 자동 연동된 경우 EMAIL일 수 있음",
+            example = "EMAIL"
+    )
     SignType provider,
+    @Schema(description = "회원 이메일. 소셜 provider가 이메일을 주지 않으면 null일 수 있음", example = "user@test.com")
     String email,
+    @Schema(description = "닉네임", example = "nick12")
     String nickname,
+    @Schema(description = "프로필 이미지 경로", example = "/profile/12")
     String profilePath,
+    @Schema(description = "비공개 계정 여부", example = "false")
     boolean privateAccount,
+    @Schema(description = "팔로워 수", example = "0")
     long followerCount,
+    @Schema(description = "팔로잉 수", example = "0")
     long followingCount
 ) {
     public static MemberResponseDto from(Member member) {

--- a/src/main/java/monochrome/libri/member/repository/SocialAccountRepository.java
+++ b/src/main/java/monochrome/libri/member/repository/SocialAccountRepository.java
@@ -1,0 +1,13 @@
+package monochrome.libri.member.repository;
+
+import monochrome.libri.member.domain.SignType;
+import monochrome.libri.member.domain.SocialAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+    Optional<SocialAccount> findByProviderAndProviderUserId(SignType provider, String providerUserId);
+
+    Optional<SocialAccount> findByMemberIdAndProvider(Long memberId, SignType provider);
+}

--- a/src/main/java/monochrome/libri/member/service/AuthService.java
+++ b/src/main/java/monochrome/libri/member/service/AuthService.java
@@ -3,6 +3,7 @@ package monochrome.libri.member.service;
 import monochrome.libri.member.dto.request.EmailLoginRequestDto;
 import monochrome.libri.member.dto.request.EmailSignUpRequestDto;
 import monochrome.libri.member.dto.request.RefreshTokenRequestDto;
+import monochrome.libri.member.dto.request.SocialLoginRequestDto;
 import monochrome.libri.member.dto.response.MemberResponseDto;
 
 /**
@@ -23,6 +24,8 @@ public interface AuthService {
      * @return 로그인한 회원 정보
      */
     MemberResponseDto loginByEmail(EmailLoginRequestDto request);
+
+    MemberResponseDto loginBySocial(SocialLoginRequestDto request);
 
     /**
      * 로그아웃

--- a/src/main/java/monochrome/libri/member/service/impl/AuthServiceImpl.java
+++ b/src/main/java/monochrome/libri/member/service/impl/AuthServiceImpl.java
@@ -1,6 +1,5 @@
 package monochrome.libri.member.service.impl;
 
-import lombok.extern.slf4j.Slf4j;
 import monochrome.libri.global.exception.ErrorCode;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.global.security.PasswordHashService;
@@ -9,28 +8,46 @@ import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.domain.MemberStatus;
 import monochrome.libri.member.domain.Role;
 import monochrome.libri.member.domain.SignType;
+import monochrome.libri.member.domain.SocialAccount;
 import monochrome.libri.member.dto.request.EmailLoginRequestDto;
 import monochrome.libri.member.dto.request.EmailSignUpRequestDto;
+import monochrome.libri.member.dto.request.SocialLoginRequestDto;
 import monochrome.libri.member.dto.response.MemberResponseDto;
 import monochrome.libri.member.repository.AuthRepository;
+import monochrome.libri.member.repository.SocialAccountRepository;
 import monochrome.libri.member.service.AuthService;
-import monochrome.libri.member.service.MemberService;
+import monochrome.libri.member.social.SocialLoginProvider;
+import monochrome.libri.member.social.SocialUserInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @Transactional(readOnly = true)
 public class AuthServiceImpl implements AuthService {
 
-    private final AuthRepository authRepository;
-    private final MemberService memberService;
-    private final PasswordHashService passwordHashService;
+    private static final Logger log = LoggerFactory.getLogger(AuthServiceImpl.class);
 
-    public AuthServiceImpl(AuthRepository authRepository, MemberService memberService, PasswordHashService passwordHashService) {
+    private final AuthRepository authRepository;
+    private final SocialAccountRepository socialAccountRepository;
+    private final PasswordHashService passwordHashService;
+    private final Map<SignType, SocialLoginProvider> socialLoginProviders;
+
+    public AuthServiceImpl(
+            AuthRepository authRepository,
+            SocialAccountRepository socialAccountRepository,
+            PasswordHashService passwordHashService,
+            List<SocialLoginProvider> socialLoginProviders
+    ) {
         this.authRepository = authRepository;
-        this.memberService = memberService;
+        this.socialAccountRepository = socialAccountRepository;
         this.passwordHashService = passwordHashService;
+        this.socialLoginProviders = toProviderMap(socialLoginProviders);
     }
 
     /**
@@ -128,6 +145,35 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
+    @Transactional
+    public MemberResponseDto loginBySocial(SocialLoginRequestDto request) {
+        SignType provider = request.provider();
+        if (provider == null || provider == SignType.EMAIL || provider == SignType.GOOGLE) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        SocialLoginProvider socialLoginProvider = socialLoginProviders.get(provider);
+        if (socialLoginProvider == null) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        SocialUserInfo userInfo = socialLoginProvider.authenticate(request);
+
+        Member member = socialAccountRepository
+                .findByProviderAndProviderUserId(userInfo.provider(), userInfo.providerUserId())
+                .map(SocialAccount::getMember)
+                .orElseGet(() -> findOrCreateMemberForSocialLogin(userInfo));
+
+        if (member.getMemberStatus() == MemberStatus.DELETE) {
+            throw new LibriException(ErrorCode.INVALID_LOGIN);
+        }
+
+        member.verifyEmailFromSocialProvider(userInfo.emailVerified());
+        log.info("auth.social-login result=success memberId={} provider={}", member.getId(), userInfo.provider());
+        return MemberResponseDto.from(member);
+    }
+
+    @Override
     public void logout(String refreshToken) {
         validateRefreshTokenText(refreshToken);
     }
@@ -144,5 +190,112 @@ public class AuthServiceImpl implements AuthService {
         if (refreshToken == null || refreshToken.isBlank()) {
             throw new LibriException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
+    }
+
+    private Map<SignType, SocialLoginProvider> toProviderMap(List<SocialLoginProvider> providers) {
+        Map<SignType, SocialLoginProvider> providerMap = new EnumMap<>(SignType.class);
+        for (SocialLoginProvider provider : providers) {
+            providerMap.put(provider.provider(), provider);
+        }
+        return providerMap;
+    }
+
+    private Member findOrCreateMemberForSocialLogin(SocialUserInfo userInfo) {
+        if (userInfo.email() != null) {
+            Member existingMember = authRepository.findByEmail(normalizeEmail(userInfo.email()))
+                    .orElse(null);
+
+            if (existingMember != null) {
+                ensureMemberCanLinkProvider(existingMember, userInfo);
+                return linkSocialAccount(existingMember, userInfo);
+            }
+        }
+
+        Member newMember = createSocialMember(userInfo);
+        Member savedMember = saveSocialMember(newMember);
+        return linkSocialAccount(savedMember, userInfo);
+    }
+
+    private void ensureMemberCanLinkProvider(Member member, SocialUserInfo userInfo) {
+        if (member.getMemberStatus() == MemberStatus.DELETE) {
+            throw new LibriException(ErrorCode.INVALID_LOGIN);
+        }
+
+        socialAccountRepository.findByMemberIdAndProvider(member.getId(), userInfo.provider())
+                .ifPresent(existing -> {
+                    if (!existing.getProviderUserId().equals(userInfo.providerUserId())) {
+                        throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+                    }
+                });
+    }
+
+    private Member linkSocialAccount(Member member, SocialUserInfo userInfo) {
+        socialAccountRepository.findByProviderAndProviderUserId(userInfo.provider(), userInfo.providerUserId())
+                .ifPresent(existing -> {
+                    if (existing.getMember().getId() != member.getId()) {
+                        throw new LibriException(ErrorCode.AUTHENTICATION_FAILED);
+                    }
+                });
+
+        if (socialAccountRepository.findByMemberIdAndProvider(member.getId(), userInfo.provider()).isEmpty()) {
+            try {
+                socialAccountRepository.save(SocialAccount.builder()
+                        .member(member)
+                        .provider(userInfo.provider())
+                        .providerUserId(userInfo.providerUserId())
+                        .emailVerifiedFromProvider(userInfo.emailVerified())
+                        .build());
+            } catch (org.springframework.dao.DataIntegrityViolationException e) {
+                throw new LibriException("소셜 계정 연동 저장에 실패했습니다.", e, ErrorCode.AUTHENTICATION_FAILED);
+            }
+        }
+
+        member.verifyEmailFromSocialProvider(userInfo.emailVerified());
+        return member;
+    }
+
+    private Member createSocialMember(SocialUserInfo userInfo) {
+        String email = normalizeEmail(userInfo.email());
+        String identitySuffix = userInfo.providerUserId().replaceAll("[^A-Za-z0-9]", "");
+        if (identitySuffix.isBlank()) {
+            identitySuffix = "user";
+        }
+        String base = userInfo.provider().name().toLowerCase() + "_" + identitySuffix;
+        String username = truncate(base, 30);
+        String nickname = truncate(base, 30);
+
+        return Member.builder()
+                .provider(userInfo.provider())
+                .providerUserId(userInfo.providerUserId())
+                .email(email)
+                .emailVerified(userInfo.emailVerified())
+                .emailVerifiedFromProvider(userInfo.emailVerified())
+                .username(username)
+                .nickname(nickname)
+                .privateAccount(false)
+                .memberStatus(MemberStatus.ACTIVE)
+                .role(Role.USER)
+                .build();
+    }
+
+    private Member saveSocialMember(Member member) {
+        try {
+            return authRepository.save(member);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            if (member.getEmail() != null) {
+                Member existingMember = authRepository.findByEmail(member.getEmail()).orElse(null);
+                if (existingMember != null) {
+                    return existingMember;
+                }
+            }
+            throw new LibriException("소셜 회원 생성에 실패했습니다.", e, ErrorCode.AUTHENTICATION_FAILED);
+        }
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
     }
 }

--- a/src/main/java/monochrome/libri/member/social/AppleSocialLoginProvider.java
+++ b/src/main/java/monochrome/libri/member/social/AppleSocialLoginProvider.java
@@ -1,0 +1,186 @@
+package monochrome.libri.member.social;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SignatureException;
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.member.config.SocialLoginProperties;
+import monochrome.libri.member.domain.SignType;
+import monochrome.libri.member.dto.request.SocialLoginRequestDto;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class AppleSocialLoginProvider implements SocialLoginProvider {
+
+    private final RestClient restClient;
+    private final SocialLoginProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public AppleSocialLoginProvider(
+            @Qualifier("appleSocialRestClient") RestClient restClient,
+            SocialLoginProperties properties,
+            ObjectMapper objectMapper
+    ) {
+        this.restClient = restClient;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public SignType provider() {
+        return SignType.APPLE;
+    }
+
+    @Override
+    public SocialUserInfo authenticate(SocialLoginRequestDto request) {
+        String idToken = normalize(request.idToken());
+        if (idToken == null) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        AppleTokenHeader header = parseHeader(idToken);
+        AppleJwk key = fetchSigningKey(header.kid(), header.alg());
+        Claims claims = parseClaims(idToken, key);
+        validateClaims(claims);
+
+        return new SocialUserInfo(
+                SignType.APPLE,
+                claims.getSubject(),
+                normalize(claims.get("email", String.class)),
+                toBoolean(claims.get("email_verified"))
+        );
+    }
+
+    private AppleTokenHeader parseHeader(String idToken) {
+        try {
+            String[] parts = idToken.split("\\.");
+            if (parts.length != 3) {
+                throw new LibriException(ErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+            byte[] decoded = Base64.getUrlDecoder().decode(parts[0]);
+            return objectMapper.readValue(decoded, AppleTokenHeader.class);
+        } catch (Exception e) {
+            throw new LibriException("애플 토큰 헤더를 파싱할 수 없습니다.", e, ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    private AppleJwk fetchSigningKey(String kid, String alg) {
+        AppleJwkSetResponse response;
+        try {
+            response = restClient.get()
+                    .uri("/auth/keys")
+                    .retrieve()
+                    .body(AppleJwkSetResponse.class);
+        } catch (RestClientException e) {
+            throw new LibriException("애플 공개키를 조회할 수 없습니다.", e, ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+
+        if (response == null || response.keys() == null) {
+            throw new LibriException(ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+
+        return response.keys().stream()
+                .filter(key -> kid.equals(key.kid()) && alg.equals(key.alg()))
+                .findFirst()
+                .orElseThrow(() -> new LibriException(ErrorCode.INVALID_SOCIAL_TOKEN));
+    }
+
+    private Claims parseClaims(String idToken, AppleJwk jwk) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(toPublicKey(jwk))
+                    .build()
+                    .parseSignedClaims(idToken)
+                    .getPayload();
+        } catch (SignatureException | IllegalArgumentException e) {
+            throw new LibriException("애플 토큰 검증에 실패했습니다.", e, ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    private RSAPublicKey toPublicKey(AppleJwk jwk) {
+        try {
+            byte[] modulusBytes = Base64.getUrlDecoder().decode(jwk.n());
+            byte[] exponentBytes = Base64.getUrlDecoder().decode(jwk.e());
+            RSAPublicKeySpec keySpec = new RSAPublicKeySpec(
+                    new BigInteger(1, modulusBytes),
+                    new BigInteger(1, exponentBytes)
+            );
+            return (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(keySpec);
+        } catch (Exception e) {
+            throw new LibriException("애플 공개키 생성에 실패했습니다.", e, ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    private void validateClaims(Claims claims) {
+        if (claims.getSubject() == null || claims.getSubject().isBlank()) {
+            throw new LibriException(ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+
+        String issuer = claims.getIssuer();
+        if (!properties.apple().issuer().equals(issuer)) {
+            throw new LibriException(ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+
+        List<String> clientIds = properties.apple().clientIds();
+        Set<String> audiences = claims.getAudience();
+        if (clientIds == null || clientIds.isEmpty() || audiences == null || audiences.stream().noneMatch(clientIds::contains)) {
+            throw new LibriException(ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    private boolean toBoolean(Object value) {
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        if (value instanceof String text) {
+            return "true".equalsIgnoreCase(text);
+        }
+        return false;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record AppleTokenHeader(
+            String kid,
+            String alg
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record AppleJwkSetResponse(
+            List<AppleJwk> keys
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record AppleJwk(
+            String kty,
+            String kid,
+            String use,
+            String alg,
+            String n,
+            String e
+    ) {
+    }
+}

--- a/src/main/java/monochrome/libri/member/social/KakaoSocialLoginProvider.java
+++ b/src/main/java/monochrome/libri/member/social/KakaoSocialLoginProvider.java
@@ -1,0 +1,86 @@
+package monochrome.libri.member.social;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import monochrome.libri.global.exception.ErrorCode;
+import monochrome.libri.global.exception.LibriException;
+import monochrome.libri.member.domain.SignType;
+import monochrome.libri.member.dto.request.SocialLoginRequestDto;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+public class KakaoSocialLoginProvider implements SocialLoginProvider {
+
+    private final RestClient restClient;
+
+    public KakaoSocialLoginProvider(@Qualifier("kakaoSocialRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @Override
+    public SignType provider() {
+        return SignType.KAKAO;
+    }
+
+    @Override
+    public SocialUserInfo authenticate(SocialLoginRequestDto request) {
+        String accessToken = normalize(request.accessToken());
+        if (accessToken == null) {
+            throw new LibriException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        KakaoUserResponse response;
+        try {
+            response = restClient.get()
+                    .uri("/v2/user/me")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(KakaoUserResponse.class);
+        } catch (RestClientException e) {
+            throw new LibriException("카카오 사용자 조회에 실패했습니다.", e, ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+
+        if (response == null || response.id() == null) {
+            throw new LibriException(ErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+
+        String email = null;
+        boolean emailVerified = false;
+        if (response.kakaoAccount() != null) {
+            email = normalize(response.kakaoAccount().email());
+            emailVerified = Boolean.TRUE.equals(response.kakaoAccount().isEmailVerified());
+        }
+
+        return new SocialUserInfo(
+                SignType.KAKAO,
+                String.valueOf(response.id()),
+                email,
+                emailVerified
+        );
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record KakaoUserResponse(
+            Long id,
+            KakaoAccount kakaoAccount
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record KakaoAccount(
+            String email,
+            Boolean isEmailVerified
+    ) {
+    }
+}

--- a/src/main/java/monochrome/libri/member/social/SocialLoginProvider.java
+++ b/src/main/java/monochrome/libri/member/social/SocialLoginProvider.java
@@ -1,0 +1,10 @@
+package monochrome.libri.member.social;
+
+import monochrome.libri.member.domain.SignType;
+import monochrome.libri.member.dto.request.SocialLoginRequestDto;
+
+public interface SocialLoginProvider {
+    SignType provider();
+
+    SocialUserInfo authenticate(SocialLoginRequestDto request);
+}

--- a/src/main/java/monochrome/libri/member/social/SocialUserInfo.java
+++ b/src/main/java/monochrome/libri/member/social/SocialUserInfo.java
@@ -1,0 +1,11 @@
+package monochrome.libri.member.social;
+
+import monochrome.libri.member.domain.SignType;
+
+public record SocialUserInfo(
+        SignType provider,
+        String providerUserId,
+        String email,
+        boolean emailVerified
+) {
+}

--- a/src/main/java/monochrome/libri/note/dto/response/BookNoteItemResponseDto.java
+++ b/src/main/java/monochrome/libri/note/dto/response/BookNoteItemResponseDto.java
@@ -1,0 +1,21 @@
+package monochrome.libri.note.dto.response;
+
+import monochrome.libri.note.domain.NoteProgressType;
+
+import java.time.LocalDateTime;
+
+public record BookNoteItemResponseDto(
+        Long noteId,
+        Long shelfId,
+        Long memberId,
+        String nickname,
+        NoteProgressType progressType,
+        int progressValue,
+        LocalDateTime createdDate,
+        String content,
+        int likeCount,
+        int commentCount,
+        boolean isLiked,
+        boolean isBookmarked
+) {
+}

--- a/src/main/java/monochrome/libri/note/dto/response/BookNoteSliceResponseDto.java
+++ b/src/main/java/monochrome/libri/note/dto/response/BookNoteSliceResponseDto.java
@@ -1,0 +1,11 @@
+package monochrome.libri.note.dto.response;
+
+import java.util.List;
+
+public record BookNoteSliceResponseDto(
+        List<BookNoteItemResponseDto> content,
+        boolean hasNext,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/monochrome/libri/note/repository/NoteRepository.java
+++ b/src/main/java/monochrome/libri/note/repository/NoteRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,4 +26,14 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     Optional<Note> findWithMemberById(long noteId);
     int countByShelfId(long shelfId);
     Optional<Note> findByIdAndShelfId(long noteId, long shelfId);
+
+    @EntityGraph(attributePaths = {"shelf", "member"})
+    Slice<Note> findByShelfBookIdAndSecretFalseOrderByCreatedDateDesc(long bookId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"shelf", "member"})
+    Slice<Note> findByShelfBookIdAndSecretFalseAndMemberIdNotInOrderByCreatedDateDesc(
+            long bookId,
+            Collection<Long> memberIds,
+            Pageable pageable
+    );
 }

--- a/src/main/java/monochrome/libri/note/service/NoteService.java
+++ b/src/main/java/monochrome/libri/note/service/NoteService.java
@@ -1,5 +1,6 @@
 package monochrome.libri.note.service;
 
+import monochrome.libri.note.dto.response.BookNoteSliceResponseDto;
 import monochrome.libri.note.dto.request.NoteCreateRequestDto;
 import monochrome.libri.note.dto.request.NoteUpdateRequestDto;
 import monochrome.libri.note.dto.response.NoteBookmarkListResponseDto;
@@ -13,6 +14,7 @@ import java.util.List;
 
 public interface NoteService {
     void createNote(long shelfId, long memberId, NoteCreateRequestDto request);
+    BookNoteSliceResponseDto getPublicNotesByBook(long bookId, long memberId, Pageable pageable);
     List<NoteSummaryResponseDto> getNotesByShelf(long shelfId, long memberId);
     NoteSliceResponseDto getNotesSliceByShelf(long shelfId, long memberId, Pageable pageable);
     NoteListResponseDto getNotesByMember(long memberId, Pageable pageable);

--- a/src/main/java/monochrome/libri/note/service/impl/NoteServiceImpl.java
+++ b/src/main/java/monochrome/libri/note/service/impl/NoteServiceImpl.java
@@ -1,6 +1,7 @@
 package monochrome.libri.note.service.impl;
 
 import monochrome.libri.block.service.BlockService;
+import monochrome.libri.book.repository.BookRepository;
 import monochrome.libri.global.exception.ErrorCode;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.member.domain.Member;
@@ -10,6 +11,8 @@ import monochrome.libri.note.domain.Note;
 import monochrome.libri.note.domain.NoteProgressType;
 import monochrome.libri.note.dto.request.NoteCreateRequestDto;
 import monochrome.libri.note.dto.request.NoteUpdateRequestDto;
+import monochrome.libri.note.dto.response.BookNoteItemResponseDto;
+import monochrome.libri.note.dto.response.BookNoteSliceResponseDto;
 import monochrome.libri.note.dto.response.NoteBookmarkItemResponseDto;
 import monochrome.libri.note.dto.response.NoteBookmarkListResponseDto;
 import monochrome.libri.note.dto.response.NoteDetailResponseDto;
@@ -35,6 +38,7 @@ import java.util.List;
 public class NoteServiceImpl implements NoteService {
 
     private final NoteRepository noteRepository;
+    private final BookRepository bookRepository;
     private final ShelfRepository shelfRepository;
     private final MemberService memberService;
     private final NoteLikeRepository noteLikeRepository;
@@ -44,6 +48,7 @@ public class NoteServiceImpl implements NoteService {
 
     public NoteServiceImpl(
             NoteRepository noteRepository,
+            BookRepository bookRepository,
             ShelfRepository shelfRepository,
             MemberService memberService,
             NoteLikeRepository noteLikeRepository,
@@ -52,6 +57,7 @@ public class NoteServiceImpl implements NoteService {
             BlockService blockService
     ) {
         this.noteRepository = noteRepository;
+        this.bookRepository = bookRepository;
         this.shelfRepository = shelfRepository;
         this.memberService = memberService;
         this.noteLikeRepository = noteLikeRepository;
@@ -87,6 +93,44 @@ public class NoteServiceImpl implements NoteService {
                 .build();
 
         noteRepository.save(note);
+    }
+
+    @Override
+    public BookNoteSliceResponseDto getPublicNotesByBook(long bookId, long memberId, Pageable pageable) {
+        if (!bookRepository.existsById(bookId)) {
+            throw new LibriException(ErrorCode.BOOK_NOT_FOUND);
+        }
+
+        Slice<Note> slice = getPublicBookNoteSlice(bookId, memberId, pageable);
+        List<Note> notes = slice.getContent();
+        List<Long> noteIds = notes.stream().map(Note::getId).toList();
+        var likedIds = resolveLikedIds(memberId, noteIds);
+        var bookmarkedIds = resolveBookmarkedIds(memberId, noteIds);
+        var commentCounts = resolveCommentCounts(noteIds);
+
+        List<BookNoteItemResponseDto> content = notes.stream()
+                .map(note -> new BookNoteItemResponseDto(
+                        note.getId(),
+                        note.getShelf().getId(),
+                        note.getMember().getId(),
+                        note.getMember().getNickname(),
+                        note.getProgressType(),
+                        note.getProgressValue(),
+                        note.getCreatedDate(),
+                        note.getContent(),
+                        note.getLikeCount(),
+                        (int) commentCounts.getOrDefault(note.getId(), 0L).longValue(),
+                        likedIds.contains(note.getId()),
+                        bookmarkedIds.contains(note.getId())
+                ))
+                .toList();
+
+        return new BookNoteSliceResponseDto(
+                content,
+                slice.hasNext(),
+                slice.getNumber(),
+                slice.getSize()
+        );
     }
 
     @Override
@@ -405,6 +449,18 @@ public class NoteServiceImpl implements NoteService {
             }
         }
         return counts;
+    }
+
+    private Slice<Note> getPublicBookNoteSlice(long bookId, long memberId, Pageable pageable) {
+        java.util.Set<Long> blockedRelationIds = blockService.getBlockedRelationMemberIds(memberId);
+        if (blockedRelationIds.isEmpty()) {
+            return noteRepository.findByShelfBookIdAndSecretFalseOrderByCreatedDateDesc(bookId, pageable);
+        }
+        return noteRepository.findByShelfBookIdAndSecretFalseAndMemberIdNotInOrderByCreatedDateDesc(
+                bookId,
+                blockedRelationIds,
+                pageable
+        );
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,13 @@ app:
     bucket: ${AWS_S3_BUCKET:}
     public-base-url: ${AWS_S3_PUBLIC_BASE_URL:}
     upload-expiration-seconds: ${AWS_S3_UPLOAD_EXPIRATION_SECONDS:300}
+  social:
+    kakao:
+      base-url: ${KAKAO_API_BASE_URL:https://kapi.kakao.com}
+    apple:
+      base-url: ${APPLE_API_BASE_URL:https://appleid.apple.com}
+      issuer: ${APPLE_ISSUER:https://appleid.apple.com}
+      client-ids: ${APPLE_CLIENT_IDS:}
 
 # Firebase FCM — 키 파일: src/main/resources/libri-firebase.json
 firebase:

--- a/src/test/java/monochrome/libri/member/service/AuthServiceImplTest.java
+++ b/src/test/java/monochrome/libri/member/service/AuthServiceImplTest.java
@@ -5,17 +5,23 @@ import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.global.security.PasswordHashService;
 import monochrome.libri.member.domain.Member;
 import monochrome.libri.member.domain.MemberStatus;
+import monochrome.libri.member.domain.SignType;
 import monochrome.libri.member.dto.request.EmailLoginRequestDto;
 import monochrome.libri.member.dto.request.EmailSignUpRequestDto;
 import monochrome.libri.member.dto.request.RefreshTokenRequestDto;
+import monochrome.libri.member.dto.request.SocialLoginRequestDto;
 import monochrome.libri.member.repository.AuthRepository;
+import monochrome.libri.member.repository.SocialAccountRepository;
+import monochrome.libri.member.social.SocialLoginProvider;
+import monochrome.libri.member.social.SocialUserInfo;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,13 +36,26 @@ class AuthServiceImplTest {
     private AuthRepository authRepository;
 
     @Mock
-    private MemberService memberService;
+    private SocialAccountRepository socialAccountRepository;
 
     @Mock
     private PasswordHashService passwordHashService;
 
-    @InjectMocks
+    @Mock
+    private SocialLoginProvider kakaoSocialLoginProvider;
+
     private monochrome.libri.member.service.impl.AuthServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        when(kakaoSocialLoginProvider.provider()).thenReturn(SignType.KAKAO);
+        service = new monochrome.libri.member.service.impl.AuthServiceImpl(
+                authRepository,
+                socialAccountRepository,
+                passwordHashService,
+                List.of(kakaoSocialLoginProvider)
+        );
+    }
 
     @Test
     void signupByEmail_rejectsDuplicate() {
@@ -98,6 +117,66 @@ class AuthServiceImplTest {
 
         assertThat(response.id()).isEqualTo(1L);
         assertThat(response.nickname()).isEqualTo(member.getNickname());
+    }
+
+    @Test
+    void loginBySocial_linksExistingEmailMember() {
+        Member member = TestFixtures.member(1L);
+        SocialUserInfo userInfo = new SocialUserInfo(SignType.KAKAO, "kakao-1", "user1@test.com", true);
+
+        when(kakaoSocialLoginProvider.authenticate(any())).thenReturn(userInfo);
+        when(socialAccountRepository.findByProviderAndProviderUserId(SignType.KAKAO, "kakao-1"))
+                .thenReturn(Optional.empty());
+        when(authRepository.findByEmail("user1@test.com")).thenReturn(Optional.of(member));
+        when(socialAccountRepository.findByMemberIdAndProvider(1L, SignType.KAKAO))
+                .thenReturn(Optional.empty());
+
+        var response = service.loginBySocial(new SocialLoginRequestDto(SignType.KAKAO, "token", null));
+
+        assertThat(response.id()).isEqualTo(1L);
+        verify(socialAccountRepository).save(any());
+    }
+
+    @Test
+    void loginBySocial_returnsLinkedMember() {
+        Member member = TestFixtures.member(1L);
+        SocialUserInfo userInfo = new SocialUserInfo(SignType.KAKAO, "kakao-1", "user1@test.com", true);
+
+        when(kakaoSocialLoginProvider.authenticate(any())).thenReturn(userInfo);
+        when(socialAccountRepository.findByProviderAndProviderUserId(SignType.KAKAO, "kakao-1"))
+                .thenReturn(Optional.of(monochrome.libri.member.domain.SocialAccount.builder()
+                        .id(1L)
+                        .member(member)
+                        .provider(SignType.KAKAO)
+                        .providerUserId("kakao-1")
+                        .emailVerifiedFromProvider(true)
+                        .build()));
+
+        var response = service.loginBySocial(new SocialLoginRequestDto(SignType.KAKAO, "token", null));
+
+        assertThat(response.id()).isEqualTo(1L);
+        verify(socialAccountRepository, never()).save(any());
+        verify(authRepository, never()).save(any());
+    }
+
+    @Test
+    void loginBySocial_createsMemberWhenNoEmailMatch() {
+        SocialUserInfo userInfo = new SocialUserInfo(SignType.KAKAO, "kakao-2", "new@test.com", true);
+        Member savedMember = TestFixtures.member(2L);
+
+        when(kakaoSocialLoginProvider.authenticate(any())).thenReturn(userInfo);
+        when(socialAccountRepository.findByProviderAndProviderUserId(SignType.KAKAO, "kakao-2"))
+                .thenReturn(Optional.empty());
+        when(authRepository.findByEmail("new@test.com")).thenReturn(Optional.empty());
+        when(authRepository.save(any(Member.class))).thenReturn(savedMember);
+        when(socialAccountRepository.findByMemberIdAndProvider(2L, SignType.KAKAO))
+                .thenReturn(Optional.empty());
+
+        var response = service.loginBySocial(new SocialLoginRequestDto(SignType.KAKAO, "token", null));
+
+        assertThat(response.id()).isEqualTo(2L);
+        verify(authRepository).save(any(Member.class));
+        verify(socialAccountRepository).save(any());
     }
 
     @Test

--- a/src/test/java/monochrome/libri/note/service/NoteServiceImplTest.java
+++ b/src/test/java/monochrome/libri/note/service/NoteServiceImplTest.java
@@ -2,6 +2,7 @@ package monochrome.libri.note.service;
 
 import monochrome.libri.TestFixtures;
 import monochrome.libri.block.service.BlockService;
+import monochrome.libri.book.repository.BookRepository;
 import monochrome.libri.comment.repository.NoteCommentRepository;
 import monochrome.libri.global.exception.LibriException;
 import monochrome.libri.member.domain.Member;
@@ -37,6 +38,9 @@ class NoteServiceImplTest {
 
     @Mock
     private NoteRepository noteRepository;
+
+    @Mock
+    private BookRepository bookRepository;
 
     @Mock
     private ShelfRepository shelfRepository;
@@ -121,6 +125,62 @@ class NoteServiceImplTest {
 
         assertThat(response.shelfId()).isEqualTo(2L);
         assertThat(response.isOwner()).isTrue();
+    }
+
+    @Test
+    void getPublicNotesByBook_filtersBlockedMembers() {
+        Member viewer = TestFixtures.member(1L);
+        Member blockedAuthor = TestFixtures.member(2L);
+        Shelf shelf = TestFixtures.shelf(20L, blockedAuthor, TestFixtures.book(3L, 100));
+        Note note = TestFixtures.note(10L, shelf, blockedAuthor, false);
+
+        when(bookRepository.existsById(3L)).thenReturn(true);
+        when(blockService.getBlockedRelationMemberIds(1L)).thenReturn(java.util.Set.of(2L));
+        when(noteRepository.findByShelfBookIdAndSecretFalseAndMemberIdNotInOrderByCreatedDateDesc(
+                eq(3L), eq(java.util.Set.of(2L)), any()
+        ))
+                .thenReturn(new SliceImpl<>(List.of(note), PageRequest.of(0, 10), false));
+        when(noteCommentRepository.countByNoteIds(List.of(10L))).thenReturn(List.of());
+        when(noteLikeRepository.findNoteIdsByMemberIdAndNoteIdIn(1L, List.of(10L))).thenReturn(List.of());
+        when(noteBookmarkRepository.findNoteIdsByMemberIdAndNoteIdIn(1L, List.of(10L))).thenReturn(List.of());
+
+        var response = service.getPublicNotesByBook(3L, 1L, PageRequest.of(0, 10));
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).memberId()).isEqualTo(2L);
+        verify(noteRepository).findByShelfBookIdAndSecretFalseAndMemberIdNotInOrderByCreatedDateDesc(
+                eq(3L), eq(java.util.Set.of(2L)), any()
+        );
+        verify(noteRepository, never()).findByShelfBookIdAndSecretFalseOrderByCreatedDateDesc(anyLong(), any());
+    }
+
+    @Test
+    void getPublicNotesByBook_usesDefaultQueryWhenNoBlockedMembers() {
+        Member author = TestFixtures.member(2L);
+        Shelf shelf = TestFixtures.shelf(20L, author, TestFixtures.book(3L, 100));
+        Note note = TestFixtures.note(10L, shelf, author, false);
+
+        when(bookRepository.existsById(3L)).thenReturn(true);
+        when(blockService.getBlockedRelationMemberIds(1L)).thenReturn(java.util.Set.of());
+        when(noteRepository.findByShelfBookIdAndSecretFalseOrderByCreatedDateDesc(eq(3L), any()))
+                .thenReturn(new SliceImpl<>(List.of(note), PageRequest.of(0, 10), false));
+        when(noteCommentRepository.countByNoteIds(List.of(10L))).thenReturn(List.of());
+        when(noteLikeRepository.findNoteIdsByMemberIdAndNoteIdIn(1L, List.of(10L))).thenReturn(List.of());
+        when(noteBookmarkRepository.findNoteIdsByMemberIdAndNoteIdIn(1L, List.of(10L))).thenReturn(List.of());
+
+        var response = service.getPublicNotesByBook(3L, 1L, PageRequest.of(0, 10));
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).shelfId()).isEqualTo(20L);
+        verify(noteRepository).findByShelfBookIdAndSecretFalseOrderByCreatedDateDesc(eq(3L), any());
+    }
+
+    @Test
+    void getPublicNotesByBook_throwsWhenBookMissing() {
+        when(bookRepository.existsById(3L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getPublicNotesByBook(3L, 1L, PageRequest.of(0, 10)))
+                .isInstanceOf(LibriException.class);
     }
 
     @Test


### PR DESCRIPTION
  - 카카오, 애플 소셜 로그인 API 추가
  - 카카오 access token, 애플 id token 검증 로직 추가
  - 소셜 로그인 후 서비스 JWT access/refresh token 발급
  - 기존 이메일 계정과 이메일이 일치하면 소셜 계정 자동 연동
  - social_account 테이블 및 저장 로직 추가
  - 프론트 연동을 위한 Swagger 응답 예시와 인증 문서 보강